### PR TITLE
Move @types to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,6 @@
     "Jamie Mason (https://github.com/JamieMason)"
   ],
   "dependencies": {
-    "@types/fs-extra": "5.0.4",
-    "@types/globby": "8.0.0",
-    "@types/jest": "23.3.1",
-    "@types/lodash": "4.14.116",
-    "@types/mock-fs": "3.6.30",
-    "@types/node": "10.9.2",
-    "@types/semver": "5.5.0",
     "chalk": "2.4.1",
     "commander": "2.17.1",
     "fs-extra": "7.0.0",
@@ -32,6 +25,13 @@
     "semver": "5.5.1"
   },
   "devDependencies": {
+    "@types/fs-extra": "5.0.4",
+    "@types/globby": "8.0.0",
+    "@types/jest": "23.3.1",
+    "@types/lodash": "4.14.116",
+    "@types/mock-fs": "3.6.30",
+    "@types/node": "10.9.2",
+    "@types/semver": "5.5.0",
     "expect-more-jest": "2.0.0",
     "jest": "23.5.0",
     "mock-fs": "4.6.0",


### PR DESCRIPTION
Can we move the typescript @types packages to devDependencies so that consumers of this package don't need to install them?