### PR TITLE
add dependency filter regex

### DIFF
--- a/src/bin-fix-mismatches.ts
+++ b/src/bin-fix-mismatches.ts
@@ -21,6 +21,10 @@ program.on('--help', () => {
   syncpack fix-mismatches
   ${chalk.grey('# uses packages defined by --source when provided')}
   syncpack fix-mismatches --source ${chalk.yellow('"apps/*/package.json"')}
+  ${chalk.grey(
+    '# uses dependencies regular expression defined by --filter when provided'
+  )}
+  syncpack fix-mismatches --filter ${chalk.yellow('"typescript|tslint"')}
   ${chalk.grey('# multiple globs can be provided like this')}
   syncpack fix-mismatches --source ${chalk.yellow(
     '"apps/*/package.json"'

--- a/src/bin-list-mismatches.ts
+++ b/src/bin-list-mismatches.ts
@@ -21,6 +21,10 @@ program.on('--help', () => {
   syncpack list-mismatches --source ${chalk.yellow(
     '"apps/*/package.json"'
   )} --source ${chalk.yellow('"core/*/package.json"')}
+  ${chalk.grey(
+    '# uses dependencies regular expression defined by --filter when provided'
+  )}
+  syncpack list-mismatches --filter ${chalk.yellow('"typescript|tslint"')}
   ${chalk.grey('# only list "devDependencies"')}
   syncpack list-mismatches --dev
   ${chalk.grey('# only list "devDependencies" and "peerDependencies"')}

--- a/src/bin-list.ts
+++ b/src/bin-list.ts
@@ -16,6 +16,10 @@ program.on('--help', () => {
   syncpack list
   ${chalk.grey('# uses packages defined by --source when provided')}
   syncpack list --source ${chalk.yellow('"apps/*/package.json"')}
+  ${chalk.grey(
+    '# uses dependencies regular expression defined by --filter when provided'
+  )}
+  syncpack list --filter ${chalk.yellow('"typescript|tslint"')}
   ${chalk.grey('# multiple globs can be provided like this')}
   syncpack list --source ${chalk.yellow(
     '"apps/*/package.json"'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -104,6 +104,11 @@ export const OPTIONS_PEER = {
   spec: '-P, --peer'
 };
 
+export const OPTIONS_FILTER_DEPENDENCIES = {
+  description: 'regex for depdendency filter',
+  spec: '-f, --filter'
+};
+
 export const OPTION_INDENT = {
   default: DEFAULT_INDENT,
   description: `override indentation. defaults to "${DEFAULT_INDENT}"`,

--- a/src/fix-mismatches.spec.ts
+++ b/src/fix-mismatches.spec.ts
@@ -18,7 +18,7 @@ describe('fix-mismatches', () => {
       '/path/2/package.json',
       '/path/3/package.json'
     ];
-    const program = getMockCommander(sources);
+    const program = getMockCommander(sources, '^((?!ignore).)*$');
     mock({
       '/path/1/package.json': JSON.stringify(one),
       '/path/2/package.json': JSON.stringify(two),
@@ -32,7 +32,7 @@ describe('fix-mismatches', () => {
   it('sets the version of dependencies with different versions to the newest of those versions found', () => {
     expect(readJsonSync('/path/1/package.json')).toEqual(
       expect.objectContaining({
-        dependencies: { chalk: '2.3.0', commander: '2.13.0' },
+        dependencies: { chalk: '2.3.0', commander: '2.13.0', ignore: '1.0.0' },
         devDependencies: {
           jest: '22.1.4',
           prettier: '1.10.2',
@@ -43,7 +43,7 @@ describe('fix-mismatches', () => {
     );
     expect(readJsonSync('/path/2/package.json')).toEqual(
       expect.objectContaining({
-        dependencies: { chalk: '2.3.0' },
+        dependencies: { chalk: '2.3.0', ignore: '2.0.0' },
         devDependencies: { jest: '22.1.4' }
       })
     );

--- a/src/fix-mismatches.ts
+++ b/src/fix-mismatches.ts
@@ -6,6 +6,7 @@ import {
   OPTION_INDENT,
   OPTION_SOURCES,
   OPTIONS_DEV,
+  OPTIONS_FILTER_DEPENDENCIES,
   OPTIONS_PEER,
   OPTIONS_PROD
 } from './constants';
@@ -24,6 +25,10 @@ export const run = async (program: CommanderApi) => {
     .option(OPTIONS_DEV.spec, OPTIONS_DEV.description)
     .option(OPTIONS_PEER.spec, OPTIONS_PEER.description)
     .option(OPTION_INDENT.spec, OPTION_INDENT.description)
+    .option(
+      OPTIONS_FILTER_DEPENDENCIES.spec,
+      OPTIONS_FILTER_DEPENDENCIES.description
+    )
     .parse(process.argv);
 
   const pkgs = getPackages(program);
@@ -31,7 +36,8 @@ export const run = async (program: CommanderApi) => {
   const indent = getIndent(program);
   const mismatchedVersionsByName = getMismatchedVersionsByName(
     dependencyTypes,
-    pkgs
+    pkgs,
+    program.filter
   );
 
   await Promise.all(

--- a/src/list-mismatches.spec.ts
+++ b/src/list-mismatches.spec.ts
@@ -9,11 +9,10 @@ describe('list-mismatches', () => {
 
   beforeAll(async () => {
     const [one, two, three] = getFixture('exact').data as IManifest[];
-    const program = getMockCommander([
-      '/path/1/package.json',
-      '/path/2/package.json',
-      '/path/3/package.json'
-    ]);
+    const program = getMockCommander(
+      ['/path/1/package.json', '/path/2/package.json', '/path/3/package.json'],
+      '^((?!ignore).)*$'
+    );
     mock({
       '/path/1/package.json': JSON.stringify(one),
       '/path/2/package.json': JSON.stringify(two),
@@ -38,6 +37,9 @@ describe('list-mismatches', () => {
     expect(spyConsole).toHaveBeenCalledWith(
       expect.stringContaining('jest'),
       expect.stringContaining('22.1.3, 22.1.4')
+    );
+    expect(spyConsole).not.toHaveBeenCalledWith(
+      expect.stringContaining('ignore')
     );
   });
 

--- a/src/list-mismatches.ts
+++ b/src/list-mismatches.ts
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import {
   OPTION_SOURCES,
   OPTIONS_DEV,
+  OPTIONS_FILTER_DEPENDENCIES,
   OPTIONS_PEER,
   OPTIONS_PROD
 } from './constants';
@@ -18,13 +19,17 @@ export const run = async (program: CommanderApi) => {
     .option(OPTIONS_PROD.spec, OPTIONS_PROD.description)
     .option(OPTIONS_DEV.spec, OPTIONS_DEV.description)
     .option(OPTIONS_PEER.spec, OPTIONS_PEER.description)
+    .option(
+      OPTIONS_FILTER_DEPENDENCIES.spec,
+      OPTIONS_FILTER_DEPENDENCIES.description
+    )
     .parse(process.argv);
-
   const dependencyTypes = getDependencyTypes(program);
   const pkgs = getPackages(program);
   const mismatchedVersionsByName = getMismatchedVersionsByName(
     dependencyTypes,
-    pkgs
+    pkgs,
+    program.filter
   );
 
   _.each(mismatchedVersionsByName, (versions, name) => {

--- a/src/list.spec.ts
+++ b/src/list.spec.ts
@@ -1,18 +1,17 @@
 import * as mock from 'mock-fs';
-import { getFixture, getMockCommander } from '../test/helpers';
 import { run } from './list';
 import { IManifest } from './typings';
+import { getFixture, getMockCommander } from '../test/helpers';
 
 describe('list', () => {
   let spyConsole: any;
 
   beforeAll(async () => {
     const [one, two, three] = getFixture('exact').data as IManifest[];
-    const program = getMockCommander([
-      '/path/1/package.json',
-      '/path/2/package.json',
-      '/path/3/package.json'
-    ]);
+    const program = getMockCommander(
+      ['/path/1/package.json', '/path/2/package.json', '/path/3/package.json'],
+      '^((?!ignore).)*$'
+    );
     mock({
       '/path/1/package.json': JSON.stringify(one),
       '/path/2/package.json': JSON.stringify(two),
@@ -52,6 +51,9 @@ describe('list', () => {
     expect(spyConsole).toHaveBeenCalledWith(
       expect.stringContaining('gulp'),
       expect.stringContaining('0.9.1, *')
+    );
+    expect(spyConsole).not.toHaveBeenCalledWith(
+      expect.stringContaining('ignore')
     );
   });
 });

--- a/src/list.ts
+++ b/src/list.ts
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import {
   OPTION_SOURCES,
   OPTIONS_DEV,
+  OPTIONS_FILTER_DEPENDENCIES,
   OPTIONS_PEER,
   OPTIONS_PROD
 } from './constants';
@@ -18,11 +19,19 @@ export const run = async (program: CommanderApi) => {
     .option(OPTIONS_PROD.spec, OPTIONS_PROD.description)
     .option(OPTIONS_DEV.spec, OPTIONS_DEV.description)
     .option(OPTIONS_PEER.spec, OPTIONS_PEER.description)
+    .option(
+      OPTIONS_FILTER_DEPENDENCIES.spec,
+      OPTIONS_FILTER_DEPENDENCIES.description
+    )
     .parse(process.argv);
 
   const dependencyTypes = getDependencyTypes(program);
   const pkgs = getPackages(program);
-  const versionsByName = getVersionsByName(dependencyTypes, pkgs);
+  const versionsByName = getVersionsByName(
+    dependencyTypes,
+    pkgs,
+    program.filter
+  );
 
   _(versionsByName)
     .entries()

--- a/src/set-semver-ranges.spec.ts
+++ b/src/set-semver-ranges.spec.ts
@@ -43,7 +43,7 @@ describe('set-semver-ranges', () => {
       .filter(({ range: sourceRange }) => !unsupported.includes(sourceRange))
       .forEach(({ filePath, range: sourceRange }) => {
         it(`sets "${sourceRange}" semver ranges to the "${targetRange}" format`, async () => {
-          const program = getMockCommander(sources);
+          const program = getMockCommander(sources, '^((?!ignore).)*$');
           program.semverRange = targetRange;
           mock(filesystem);
           const noop = () => undefined;

--- a/test/fixtures/any.json
+++ b/test/fixtures/any.json
@@ -2,7 +2,8 @@
   {
     "dependencies": {
       "chalk": "*",
-      "commander": "*"
+      "commander": "*",
+      "ignore": "1.0.0"
     },
     "devDependencies": {
       "jest": "*",

--- a/test/fixtures/exact.json
+++ b/test/fixtures/exact.json
@@ -2,7 +2,8 @@
   {
     "dependencies": {
       "chalk": "2.3.0",
-      "commander": "2.13.0"
+      "commander": "2.13.0",
+      "ignore": "1.0.0"
     },
     "devDependencies": {
       "jest": "22.1.3",
@@ -16,7 +17,8 @@
   },
   {
     "dependencies": {
-      "chalk": "1.0.0"
+      "chalk": "1.0.0",
+      "ignore": "2.0.0"
     },
     "devDependencies": {
       "jest": "22.1.4"

--- a/test/fixtures/gt.json
+++ b/test/fixtures/gt.json
@@ -2,7 +2,8 @@
   {
     "dependencies": {
       "chalk": ">2.3.0",
-      "commander": ">2.13.0"
+      "commander": ">2.13.0",
+      "ignore": "1.0.0"
     },
     "devDependencies": {
       "jest": ">22.1.3",

--- a/test/fixtures/gte.json
+++ b/test/fixtures/gte.json
@@ -2,7 +2,8 @@
   {
     "dependencies": {
       "chalk": ">=2.3.0",
-      "commander": ">=2.13.0"
+      "commander": ">=2.13.0",
+      "ignore": "1.0.0"
     },
     "devDependencies": {
       "jest": ">=22.1.3",

--- a/test/fixtures/loose.json
+++ b/test/fixtures/loose.json
@@ -2,7 +2,8 @@
   {
     "dependencies": {
       "chalk": "2.x.x",
-      "commander": "2.x.x"
+      "commander": "2.x.x",
+      "ignore": "1.0.0"
     },
     "devDependencies": {
       "jest": "22.x.x",

--- a/test/fixtures/lt.json
+++ b/test/fixtures/lt.json
@@ -2,7 +2,8 @@
   {
     "dependencies": {
       "chalk": "<2.3.0",
-      "commander": "<2.13.0"
+      "commander": "<2.13.0",
+      "ignore": "1.0.0"
     },
     "devDependencies": {
       "jest": "<22.1.3",

--- a/test/fixtures/lte.json
+++ b/test/fixtures/lte.json
@@ -2,7 +2,8 @@
   {
     "dependencies": {
       "chalk": "<=2.3.0",
-      "commander": "<=2.13.0"
+      "commander": "<=2.13.0",
+      "ignore": "1.0.0"
     },
     "devDependencies": {
       "jest": "<=22.1.3",

--- a/test/fixtures/minor.json
+++ b/test/fixtures/minor.json
@@ -2,7 +2,8 @@
   {
     "dependencies": {
       "chalk": "^2.3.0",
-      "commander": "^2.13.0"
+      "commander": "^2.13.0",
+      "ignore": "1.0.0"
     },
     "devDependencies": {
       "jest": "^22.1.3",

--- a/test/fixtures/patch.json
+++ b/test/fixtures/patch.json
@@ -2,7 +2,8 @@
   {
     "dependencies": {
       "chalk": "~2.3.0",
-      "commander": "~2.13.0"
+      "commander": "~2.13.0",
+      "ignore": "1.0.0"
     },
     "devDependencies": {
       "jest": "~22.1.3",

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -23,9 +23,13 @@ export const getFixture = (name: string, transform = (a: any | any[]) => a) => {
   return { data, json };
 };
 
-export const getMockCommander = (source: string[]) => {
+export const getMockCommander = (
+  source: string[],
+  dependencyFilterString?: string
+) => {
   const program = ({
     command: () => program,
+    filter: dependencyFilterString,
     option: () => program,
     parse: () => program,
     source,


### PR DESCRIPTION
Howdy @JamieMason , thanks for providing syncpack to the JavaScript community!

I'd like your feedback on this pull request. I work at a company that would like to use this tool, but we need it to support one more feature: the ability to only sync certain packages.

The use case is: Our root packages.json has a number of dependencies that we don't want to sync with child folders that contain package.json files; we selectively would like to enable the packages that we sync.

The current workaround we use is to pipe the output of the syncpackage "list" command into a script that has these dependencies of interest hardcoded, and checks to make sure the version list length for those dependencies is not > 1. We figured this PR would be a better solution and one that would be useful to others, too.

The reason I chose a regex instead of list of exact string matches is that we have instances where we'd like to sync all internal packages, say @companyname/.*, and the regex seems less fragile than hardcoding one packages at a time.

Let me know if there's anything I can do to make it easier to review on your end. Thanks!