### PR TITLE
filter should be string not boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ syncpack fix-mismatches
 syncpack fix-mismatches --source "apps/*/package.json"
 # multiple globs can be provided like this
 syncpack fix-mismatches --source "apps/*/package.json" --source "core/*/package.json"
+# uses packages that pass the regex defined by --filter when provided
+syncpack fix-mismatches --filter "^package_name$"
 # only fix "devDependencies"
 syncpack fix-mismatches --dev
 # only fix "devDependencies" and "peerDependencies"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -106,7 +106,7 @@ export const OPTIONS_PEER = {
 
 export const OPTIONS_FILTER_DEPENDENCIES = {
   description: 'regex for depdendency filter',
-  spec: '-f, --filter'
+  spec: '-f, --filter [pattern]'
 };
 
 export const OPTION_INDENT = {


### PR DESCRIPTION
🤦‍♂ , I totally overlooked this... didn't realize that what we put in the "spec" field in the option will affect how the parser reads the input in. I should have tested the CLI itself, instead of just running the test cases on the previous PR. Apologies for wasting your time!

I updated the README while I was at it. Again, sorry about it!

## Test plan
Test the actual CLI itself, not just the internal functions.

Run `yarn build`
Copy the entire folder into node_modules in a sample project
Run the command to verify it worked:
```js
ip-192-168-7-41:js $ node node_modules/syncpack/dist/bin-list-mismatches.js --filter "^tslint$"
tslint ^5.15.0, ^5.14.0, ^5.12.1, 5.9.1, 5.12.1, ^5.1.0
ip-192-168-7-41:js $ echo $?
1
```