### PR TITLE
feat(lib): GetPackages to support yarn workspaces

### DIFF
--- a/src/lib/get-packages.spec.ts
+++ b/src/lib/get-packages.spec.ts
@@ -1,6 +1,5 @@
 import { removeSync } from 'fs-extra';
 import * as mock from 'mock-fs';
-import { resolve } from 'path';
 import { getMockCommander } from '../../test/helpers';
 import { getPackages } from './get-packages';
 
@@ -44,5 +43,27 @@ describe('getPackages', () => {
       { data: { name: 'packages-a' }, path: 'packages/a/package.json' },
       { data: { name: 'packages-b' }, path: 'packages/b/package.json' }
     ]);
+  });
+
+  describe('yarn workspaces', () => {
+    afterEach(() => {
+      mock.restore();
+    });
+
+    beforeEach(() => {
+      mock({
+        'packages/a/package.json': JSON.stringify({ name: 'packages-a' }),
+        'packages/b/package.json': JSON.stringify({ name: 'packages-b' }),
+        'package.json': JSON.stringify({ workspaces: ['packages/*'] })
+      });
+    });
+
+    it('should resolve correctly', () => {
+      const program = getMockCommander([]);
+      expect(getPackages(program)).toEqual([
+        { data: { name: 'packages-a' }, path: 'packages/a/package.json' },
+        { data: { name: 'packages-b' }, path: 'packages/b/package.json' }
+      ]);
+    });
   });
 });

--- a/src/lib/get-packages.ts
+++ b/src/lib/get-packages.ts
@@ -8,12 +8,8 @@ export const getSources = (program: CommanderApi): string[] => {
   if (program.source && program.source.length) {
     return program.source;
   }
-  const lernaPath = resolve(process.cwd(), 'lerna.json');
-  const lerna = readJsonSync(lernaPath, { throws: false });
-  if (lerna && lerna.packages && lerna.packages.length) {
-    return lerna.packages.map((glob: string) => join(glob, 'package.json'));
-  }
-  return OPTION_SOURCES.default;
+
+  return getYarnWorkspaces() || getLernaPackages() || OPTION_SOURCES.default;
 };
 
 export const getPackages = (program: CommanderApi): IManifestDescriptor[] =>
@@ -21,3 +17,21 @@ export const getPackages = (program: CommanderApi): IManifestDescriptor[] =>
     data: readJsonSync(filePath),
     path: filePath
   }));
+
+const getYarnWorkspaces = (): string[] | null => {
+  const rootPackageJson = resolve(process.cwd(), 'package.json');
+  const pkgJson = readJsonSync(rootPackageJson, { throws: false });
+  if (pkgJson && pkgJson.workspaces && pkgJson.workspaces.length) {
+    return pkgJson.workspaces.map((glob: string) => join(glob, 'package.json'));
+  }
+  return null;
+};
+
+const getLernaPackages = (): string[] | null => {
+  const lernaPath = resolve(process.cwd(), 'lerna.json');
+  const lerna = readJsonSync(lernaPath, { throws: false });
+  if (lerna && lerna.packages && lerna.packages.length) {
+    return lerna.packages.map((glob: string) => join(glob, 'package.json'));
+  }
+  return null;
+};


### PR DESCRIPTION
With this PR I aim to support yarn workspaces.

There is 1 assumption; If you've got `yarn workspaces`, I assume you're not using `lerna bootstrap`, and thus packages listed in `lerna.json` are _ignored_. We could potentially `console.warn` to the user and make them aware of that maybe? _Or_ maybe concat, and de-dupe the list? But afaik, lerna and yarn workspaces don't play well together from a `bootstrap` perspective, but rather as a task runner.

resolves #20