### PR TITLE
Allow multiple filters to be specified for compatible syncpack sub commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ syncpack fix-mismatches --source "apps/*/package.json"
 syncpack fix-mismatches --source "apps/*/package.json" --source "core/*/package.json"
 # uses dependencies regular expression defined by --filter when provided
 syncpack fix-mismatches --filter "typescript|tslint"
+# multiple filters can be provided like this
+syncpack fix-mismatches --filter "@react" --filter "webpack"
 # only inspect "devDependencies"
 syncpack fix-mismatches --dev
 # only inspect "devDependencies" and "peerDependencies"
@@ -124,6 +126,8 @@ syncpack list --source "apps/*/package.json"
 syncpack list --source "apps/*/package.json" --source "core/*/package.json"
 # uses dependencies regular expression defined by --filter when provided
 syncpack list --filter "typescript|tslint"
+# multiple filters can be provided like this
+syncpack list --filter "@react" --filter "webpack"
 # only inspect "devDependencies"
 syncpack list --dev
 # only inspect "devDependencies" and "peerDependencies"
@@ -160,6 +164,8 @@ syncpack list-mismatches --source "apps/*/package.json"
 syncpack list-mismatches --source "apps/*/package.json" --source "core/*/package.json"
 # uses dependencies regular expression defined by --filter when provided
 syncpack list-mismatches --filter "typescript|tslint"
+# multiple filters can be provided like this
+syncpack list-mismatches --filter "@react" --filter "webpack"
 # only inspect "devDependencies"
 syncpack list-mismatches --dev
 # only inspect "devDependencies" and "peerDependencies"
@@ -198,6 +204,8 @@ syncpack set-semver-ranges --source "apps/*/package.json"
 syncpack set-semver-ranges --source "apps/*/package.json" --source "core/*/package.json"
 # uses dependencies regular expression defined by --filter when provided
 syncpack set-semver-ranges --filter "typescript|tslint"
+# multiple filters can be provided like this
+syncpack set-semver-ranges --filter "@react" --filter "webpack"
 # use ~ range instead of default ""
 syncpack set-semver-ranges --semver-range ~
 # set ~ range in "devDependencies"

--- a/src/bin-fix-mismatches.ts
+++ b/src/bin-fix-mismatches.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import program = require('commander');
 import { fixMismatchesToDisk } from './commands/fix-mismatches';
 import { option } from './constants';
+import { parseFilterArgs } from './lib/parse-filter-args';
 
 program.description(
   `
@@ -29,6 +30,8 @@ Examples:
   syncpack fix-mismatches --source {yellow "apps/*/package.json"} --source {yellow "core/*/package.json"}
   {dim # uses dependencies regular expression defined by --filter when provided}
   syncpack fix-mismatches --filter {yellow "typescript|tslint"}
+  {dim # multiple filters can be provided like this}
+  syncpack fix-mismatches --filter {yellow "@react"} --filter {yellow "webpack"}
   {dim # only inspect "devDependencies"}
   syncpack fix-mismatches --dev
   {dim # only inspect "devDependencies" and "peerDependencies"}
@@ -54,7 +57,7 @@ program
 
 fixMismatchesToDisk({
   dev: Boolean(program.dev),
-  filter: new RegExp(program.filter ? program.filter : '.'),
+  filter: parseFilterArgs(program.filter),
   indent: program.indent ? program.indent : '  ',
   peer: Boolean(program.peer),
   prod: Boolean(program.prod),

--- a/src/bin-list-mismatches.ts
+++ b/src/bin-list-mismatches.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import program = require('commander');
 import { listMismatchesFromDisk } from './commands/list-mismatches';
 import { option } from './constants';
+import { parseFilterArgs } from './lib/parse-filter-args';
 
 program.description(
   `
@@ -22,6 +23,8 @@ Examples:
   syncpack list-mismatches --source {yellow "apps/*/package.json"} --source {yellow "core/*/package.json"}
   {dim # uses dependencies regular expression defined by --filter when provided}
   syncpack list-mismatches --filter {yellow "typescript|tslint"}
+  {dim # multiple filters can be provided like this}
+  syncpack list-mismatches --filter {yellow "@react"} --filter {yellow "webpack"}
   {dim # only inspect "devDependencies"}
   syncpack list-mismatches --dev
   {dim # only inspect "devDependencies" and "peerDependencies"}
@@ -50,7 +53,7 @@ program
 
 listMismatchesFromDisk({
   dev: Boolean(program.dev),
-  filter: new RegExp(program.filter ? program.filter : '.'),
+  filter: parseFilterArgs(program.filter),
   peer: Boolean(program.peer),
   prod: Boolean(program.prod),
   sources: Array.isArray(program.source) ? program.source : [],

--- a/src/bin-list.ts
+++ b/src/bin-list.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import program = require('commander');
 import { listFromDisk } from './commands/list';
 import { option } from './constants';
+import { parseFilterArgs } from './lib/parse-filter-args';
 
 program.description('  List all dependencies required by your packages.');
 
@@ -46,7 +47,7 @@ program
 
 listFromDisk({
   dev: Boolean(program.dev),
-  filter: new RegExp(program.filter ? program.filter : '.'),
+  filter: parseFilterArgs(program.filter),
   peer: Boolean(program.peer),
   prod: Boolean(program.prod),
   sources: Array.isArray(program.source) ? program.source : [],

--- a/src/bin-set-semver-ranges.ts
+++ b/src/bin-set-semver-ranges.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import program = require('commander');
 import { setSemverRangesToDisk } from './commands/set-semver-ranges';
 import { option } from './constants';
+import { parseFilterArgs } from './lib/parse-filter-args';
 
 program.description(
   `
@@ -22,6 +23,8 @@ Examples:
   syncpack set-semver-ranges --source {yellow "apps/*/package.json"} --source {yellow "core/*/package.json"}
   {dim # uses dependencies regular expression defined by --filter when provided}
   syncpack set-semver-ranges --filter {yellow "typescript|tslint"}
+  {dim # multiple filters can be provided like this}
+  syncpack et-semver-ranges --filter {yellow "@react"} --filter {yellow "webpack"}
   {dim # use ~ range instead of default ""}
   syncpack set-semver-ranges --semver-range ~
   {dim # set ~ range in "devDependencies"}
@@ -66,7 +69,7 @@ program
 
 setSemverRangesToDisk({
   dev: Boolean(program.dev),
-  filter: new RegExp(program.filter ? program.filter : '.'),
+  filter: parseFilterArgs(program.filter),
   indent: program.indent ? program.indent : '  ',
   peer: Boolean(program.peer),
   prod: Boolean(program.prod),

--- a/src/commands/fix-mismatches.spec.ts
+++ b/src/commands/fix-mismatches.spec.ts
@@ -15,7 +15,7 @@ describe('fixMismatches', () => {
 
   it('sets all dependencies installed with different versions to the highest version', () => {
     const wrappers = [mock.wrapper('a', ['foo@0.1.0']), mock.wrapper('b', ['foo@0.2.0'])];
-    fixMismatches(['dependencies'], /./, wrappers);
+    fixMismatches(['dependencies'], [/./], wrappers);
     expect(wrappers).toMatchSnapshot();
   });
 });

--- a/src/commands/fix-mismatches.ts
+++ b/src/commands/fix-mismatches.ts
@@ -11,16 +11,18 @@ import { log } from './lib/log';
 
 export interface Options {
   dev: boolean;
-  filter: RegExp;
+  filter: RegExp[];
   indent: string;
   peer: boolean;
   prod: boolean;
   sources: string[];
 }
 
-export const fixMismatches = (dependencyTypes: DependencyType[], filter: RegExp, wrappers: SourceWrapper[]): void => {
+export const fixMismatches = (dependencyTypes: DependencyType[], filter: RegExp[], wrappers: SourceWrapper[]): void => {
   const iterator = getMismatchedDependencies(dependencyTypes, wrappers);
-  const mismatches = Array.from(iterator).filter(({ name }) => name.search(filter) !== -1);
+  const mismatches = Array.from(iterator).filter(({ name }) =>
+    filter.reduce((matchesFilter: boolean, f) => matchesFilter || name.search(f) !== -1, false),
+  );
 
   mismatches.forEach((installedPackage) => {
     const versions = installedPackage.installations.map((installation) => installation.version);

--- a/src/commands/list-mismatches.spec.ts
+++ b/src/commands/list-mismatches.spec.ts
@@ -17,7 +17,7 @@ describe('listMismatches', () => {
 
   it('outputs all dependencies installed with different versions', () => {
     const wrappers = [mock.wrapper('a', ['foo@0.1.0']), mock.wrapper('b', ['foo@0.2.0'])];
-    listMismatches(['dependencies'], /./, wrappers);
+    listMismatches(['dependencies'], [/./], wrappers);
     expect(log.mock.calls).toMatchSnapshot();
   });
 });

--- a/src/commands/list-mismatches.ts
+++ b/src/commands/list-mismatches.ts
@@ -7,7 +7,7 @@ import { log } from './lib/log';
 
 interface Options {
   dev: boolean;
-  filter: RegExp;
+  filter: RegExp[];
   peer: boolean;
   prod: boolean;
   sources: string[];
@@ -15,11 +15,13 @@ interface Options {
 
 export const listMismatches = (
   dependencyTypes: DependencyType[],
-  filter: RegExp,
+  filter: RegExp[],
   wrappers: SourceWrapper[],
 ): InstalledPackage[] => {
   const iterator = getMismatchedDependencies(dependencyTypes, wrappers);
-  const mismatches = Array.from(iterator).filter(({ name }) => name.search(filter) !== -1);
+  const mismatches = Array.from(iterator).filter(({ name }) =>
+    filter.reduce((matchesFilter: boolean, f) => matchesFilter || name.search(f) !== -1, false),
+  );
 
   mismatches.sort(sortByName).forEach(({ name, installations }) => {
     log(chalk`{red ✕ ${name}}`);

--- a/src/commands/list.spec.ts
+++ b/src/commands/list.spec.ts
@@ -17,7 +17,7 @@ describe('list', () => {
 
   it('outputs all dependencies', () => {
     const wrappers = [mock.wrapper('a', ['foo@0.1.0']), mock.wrapper('b', ['foo@0.2.0'])];
-    list(['dependencies'], /./, wrappers);
+    list(['dependencies'], [/./], wrappers);
     expect(log.mock.calls).toMatchSnapshot();
   });
 });

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -7,15 +7,17 @@ import { log } from './lib/log';
 
 interface Options {
   dev: boolean;
-  filter: RegExp;
+  filter: RegExp[];
   peer: boolean;
   prod: boolean;
   sources: string[];
 }
 
-export const list = (dependencyTypes: DependencyType[], filter: RegExp, wrappers: SourceWrapper[]): void => {
+export const list = (dependencyTypes: DependencyType[], filter: RegExp[], wrappers: SourceWrapper[]): void => {
   const iterator = getDependencies(dependencyTypes, wrappers);
-  const packages = Array.from(iterator).filter(({ name }) => name.search(filter) !== -1);
+  const packages = Array.from(iterator).filter(({ name }) =>
+    filter.reduce((matchesFilter: boolean, f) => matchesFilter || name.search(f) !== -1, false),
+  );
 
   packages.sort(sortByName).forEach(({ name, installations }) => {
     const versions = installations.map(({ version }) => version);

--- a/src/commands/set-semver-ranges.spec.ts
+++ b/src/commands/set-semver-ranges.spec.ts
@@ -6,7 +6,7 @@ describe('setSemverRanges', () => {
   it('sets all versions to use the supplied range', () => {
     const range = '~';
     const wrapper = mock.wrapper('a', ['foo@0.1.0', 'bar@2.0.0']);
-    setSemverRanges(range, ['dependencies'], /./, wrapper);
+    setSemverRanges(range, ['dependencies'], [/./], wrapper);
     expect(wrapper).toEqual(mock.wrapper('a', ['foo@~0.1.0', 'bar@~2.0.0']));
   });
 });

--- a/src/commands/set-semver-ranges.ts
+++ b/src/commands/set-semver-ranges.ts
@@ -7,7 +7,7 @@ import { writeIfChanged } from './lib/write-if-changed';
 
 interface Options {
   dev: boolean;
-  filter: RegExp;
+  filter: RegExp[];
   indent: string;
   peer: boolean;
   prod: boolean;
@@ -30,12 +30,17 @@ export const setSemverRange = (range: string, version: string): string => {
 export const setSemverRanges = (
   semverRange: string,
   dependencyTypes: DependencyType[],
-  filter: RegExp,
+  filter: RegExp[],
   wrapper: SourceWrapper,
 ): void => {
   const iterator = getDependencies(dependencyTypes, [wrapper]);
   for (const installedPackage of iterator) {
-    if (installedPackage.name.search(filter) !== -1) {
+    const installedPackageNameInFilter = filter.reduce(
+      (matchesFilter: boolean, f) => matchesFilter || installedPackage.name.search(f) !== -1,
+      false,
+    );
+
+    if (installedPackageNameInFilter) {
       for (const installation of installedPackage.installations) {
         const { name, type, version } = installation;
         const dependencies = installation.source.contents[type];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,7 +41,7 @@ export const ALL_PATTERNS = [MONOREPO_PATTERN, PACKAGES_PATTERN];
 
 interface OptionsByName {
   dev: [string, string];
-  filter: [string, string];
+  filter: [string, string, typeof collect, string[]];
   indent: [string, string];
   peer: [string, string];
   prod: [string, string];
@@ -51,7 +51,7 @@ interface OptionsByName {
 
 export const option: OptionsByName = {
   dev: ['-d, --dev', 'include devDependencies'],
-  filter: ['-f, --filter [pattern]', 'regex for dependency filter'],
+  filter: ['-f, --filter [pattern]', 'regex for dependency filter', collect, []],
   indent: ['-i, --indent [value]', `override indentation. defaults to "${DEFAULT_INDENT}"`],
   peer: ['-P, --peer', 'include peerDependencies'],
   prod: ['-p, --prod', 'include dependencies'],

--- a/src/lib/parse-filter-args.spec.ts
+++ b/src/lib/parse-filter-args.spec.ts
@@ -1,0 +1,23 @@
+import { parseFilterArgs } from './parse-filter-args';
+
+describe('parseFilterArgs', () => {
+  it('converts the filter args from an array of strings to an array of RegExps', () => {
+    const parsedFilterArgs = parseFilterArgs(['@react', 'webpack']);
+    expect(parsedFilterArgs.length).toEqual(2);
+
+    expect(parsedFilterArgs[0].toString()).toEqual('/@react/');
+    expect(parsedFilterArgs[1].toString()).toEqual('/webpack/');
+  });
+
+  it('converts the filter args from a string to an array of RegExps', () => {
+    const parsedFilterArgs = parseFilterArgs('@react');
+    expect(parsedFilterArgs.length).toEqual(1);
+    expect(parsedFilterArgs[0].toString()).toEqual('/@react/');
+  });
+
+  it('returns a match all RegExp when an empty string is specified', () => {
+    const parsedFilterArgs = parseFilterArgs('');
+    expect(parsedFilterArgs.length).toEqual(1);
+    expect(parsedFilterArgs[0].toString()).toEqual('/(?:)/');
+  });
+});

--- a/src/lib/parse-filter-args.ts
+++ b/src/lib/parse-filter-args.ts
@@ -1,0 +1,8 @@
+export const parseFilterArgs = (filterArgs: string | string[]): RegExp[] => {
+  if (Array.isArray(filterArgs)) {
+    return filterArgs.map((filter) => new RegExp(filter));
+  } else if (!filterArgs) {
+    [new RegExp('.')];
+  }
+  return [new RegExp(filterArgs)];
+};


### PR DESCRIPTION
## Description (What)

Allows multiple filters to be specified for compatible syncpack sub commands. So to fix mismatches for multiple dependencies we can do something like:

```sh
syncpack fix-mismatches -f "@apollo" -f "webpack"
```

I also specified an `.nvmrc` with the latest node version since we use something a little more outdated and had to pick something. I would be happy to change this to the node version you are using instead!

## Justification (Why)

At QuickBase we had a use case where we had a monorepo with different dependency versions and combinations and needed to globally update all of these packages. It was easiest to get a list of all the packages in the repository using `list-mismatches` then be able to run `fix-mismatches` in one go rather than scripting a for-loop for calling `fix-mismatches` for each dependency that needed to be fixed.

For example:
```
.
├── packages
│   ├── A
│   ├── B
│   ├── C
```

Package A has dependencies `webpack`, `url-loader` and, `css-loader`
Package B has dependencies `webpack` and, `css-loader`
Package C has dependencies `@apollo`, `webpack` and, `css-loader`

To fix all of the mismatches at once I could call:
```
syncpack fix-mismatches -f "webpack" -f "@apollo" -f "url-loader" -f "css-loader"
```

## How Can This Be Tested?

- ensure you have node version >=12.0.0 for eslint compatibility
- run 
  ```sh
  yarn install
  yarn test
  yarn build
  ```
- go to another mono repository with multiple packages, ensure that you multiple filters are allowed for all compatible syncpack subcommands