### PR TITLE
pnpm support

### DIFF
--- a/.github/README_CONTENT.md
+++ b/.github/README_CONTENT.md
@@ -11,6 +11,8 @@ package.json files are resolved in this order of precendence:
 1. If `--source`
    [glob patterns](https://github.com/isaacs/node-glob#glob-primer) are
    provided, use those.
+1. If using [Pnpm Workspaces](https://pnpm.js.org/en/workspaces),
+   read `packages` from `pnpm-workspace.yaml` in the root of the current project.
 1. If using [Yarn Workspaces](https://yarnpkg.com/lang/en/docs/workspaces/),
    read `workspaces` from `./package.json`.
 1. If using [Lerna](https://lerna.js.org/), read `packages` from `./lerna.json`.

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,6 +1,6 @@
 # syncpack
 
-Manage multiple package.json files, such as in Lerna Monorepos and Pnpm/Yarn Workspaces
+Manage multiple package.json files, such as in Lerna Monorepos and Yarn/Pnpm Workspaces
 
 ## Installation
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,12 +1,13 @@
 # syncpack
 
-Manage multiple package.json files, such as in Lerna Monorepos and Yarn Workspaces
+Manage multiple package.json files, such as in Lerna Monorepos and Pnpm/Yarn Workspaces
 
 ## Installation
 
 This is a [Node.js](https://nodejs.org/) module available through the 
 [npm registry](https://www.npmjs.com/). It can be installed using the 
-[`npm`](https://docs.npmjs.com/getting-started/installing-npm-packages-locally)
+[`npm`](https://docs.npmjs.com/getting-started/installing-npm-packages-locally),
+[`pnpm`](https://pnpm.js.org/en/installation)
 or 
 [`yarn`](https://yarnpkg.com/en/)
 command line tools.
@@ -27,6 +28,7 @@ npm test
 - [chalk](https://ghub.io/chalk): Terminal string styling done right
 - [commander](https://ghub.io/commander): the complete solution for node.js command-line programs
 - [fs-extra](https://ghub.io/fs-extra): fs-extra contains methods that aren&#39;t included in the vanilla Node.js fs package. Such as recursive mkdir, copy, and remove.
+- [@manypkg/get-packages](https://github.com/Thinkmill/manypkg/tree/master/packages/get-packages): a simple utility to get the packages from a monorepo, whether they're using Yarn, Bolt or pnpm
 - [glob](https://ghub.io/glob): a little globber
 - [semver](https://ghub.io/semver): The semantic version parser used by npm.
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "Matt Sprague (https://github.com/uforic)"
   ],
   "dependencies": {
+    "@manypkg/get-packages": "^1.1.0",
     "chalk": "4.1.0",
     "commander": "6.0.0",
     "fs-extra": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -21,28 +21,28 @@
   ],
   "dependencies": {
     "chalk": "4.1.0",
-    "commander": "5.1.0",
+    "commander": "6.0.0",
     "fs-extra": "9.0.1",
     "glob": "7.1.6",
     "semver": "7.3.2"
   },
   "devDependencies": {
     "@types/fs-extra": "9.0.1",
-    "@types/glob": "7.1.2",
-    "@types/jest": "26.0.0",
+    "@types/glob": "7.1.3",
+    "@types/jest": "26.0.7",
     "@types/mock-fs": "4.10.0",
-    "@types/node": "14.0.13",
-    "@types/semver": "7.2.0",
-    "@typescript-eslint/eslint-plugin": "3.3.0",
-    "@typescript-eslint/parser": "3.3.0",
-    "eslint": "7.2.0",
+    "@types/node": "14.0.26",
+    "@types/semver": "7.3.1",
+    "@typescript-eslint/eslint-plugin": "3.7.1",
+    "@typescript-eslint/parser": "3.7.1",
+    "eslint": "7.5.0",
     "expect-more-jest": "5.2.0",
-    "jest": "26.0.1",
+    "jest": "26.1.0",
     "mock-fs": "4.12.0",
     "prettier": "2.0.5",
     "rimraf": "3.0.2",
-    "ts-jest": "26.1.0",
-    "typescript": "3.9.5"
+    "ts-jest": "26.1.4",
+    "typescript": "3.9.7"
   },
   "engines": {
     "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "syncpack",
-  "description": "Manage multiple package.json files, such as in Lerna Monorepos and Yarn Workspaces",
-  "version": "5.0.3",
+  "description": "Manage multiple package.json files, such as in Lerna Monorepos and Yarn/Pnpm Workspaces",
   "author": "Jamie Mason <jamie@foldleft.io> (https://github.com/JamieMason)",
   "bin": {
     "syncpack": "dist/bin.js",
@@ -17,7 +16,8 @@
     "Jamie Mason (https://github.com/JamieMason)",
     "Luis Vieira (https://github.com/luisvieiragmr)",
     "Marais Rossouw (https://github.com/maraisr)",
-    "Matt Sprague (https://github.com/uforic)"
+    "Matt Sprague (https://github.com/uforic)",
+    "Aparajita Fishman (https://github.com/aparajita)"
   ],
   "dependencies": {
     "@manypkg/get-packages": "^1.1.0",
@@ -64,6 +64,7 @@
     "package",
     "package-json",
     "packages",
+    "pnpm",
     "semver",
     "workspace",
     "yarn"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "syncpack",
   "description": "Manage multiple package.json files, such as in Lerna Monorepos and Yarn/Pnpm Workspaces",
+  "version": "5.1.0",
   "author": "Jamie Mason <jamie@foldleft.io> (https://github.com/JamieMason)",
   "bin": {
     "syncpack": "dist/bin.js",

--- a/src/bin-fix-mismatches.ts
+++ b/src/bin-fix-mismatches.ts
@@ -16,9 +16,10 @@ program.on('--help', () => {
   console.log(chalk`
 Resolving Packages:
   1. If {yellow --source} globs are provided, use those.
-  2. If using Yarn Workspaces, read {yellow workspaces} from {yellow package.json}.
-  3. If using Lerna, read {yellow packages} from {yellow lerna.json}.
-  4. Default to {yellow "package.json"} and {yellow "packages/*/package.json"}.
+  2. If using Pnpm Workspaces, read {yellow packages} from {yellow pnpm-workspace.yaml} in the root of the project.
+  3. If using Yarn Workspaces, read {yellow workspaces} from {yellow package.json}.
+  4. If using Lerna, read {yellow packages} from {yellow lerna.json}.
+  5. Default to {yellow "package.json"} and {yellow "packages/*/package.json"}.
 
 Examples:
   {dim # uses defaults for resolving packages}
@@ -40,6 +41,7 @@ Reference:
   globs            {blue.underline https://github.com/isaacs/node-glob#glob-primer}
   lerna.json       {blue.underline https://github.com/lerna/lerna#lernajson}
   Yarn Workspaces  {blue.underline https://yarnpkg.com/lang/en/docs/workspaces}
+  Pnpm Workspaces  {blue.underline https://pnpm.js.org/en/workspaces}
 `);
 });
 

--- a/src/bin-format.ts
+++ b/src/bin-format.ts
@@ -27,14 +27,16 @@ Examples:
 
 Resolving Packages:
   1. If {yellow --source} globs are provided, use those.
-  2. If using Yarn Workspaces, read {yellow workspaces} from {yellow package.json}.
-  3. If using Lerna, read {yellow packages} from {yellow lerna.json}.
-  4. Default to {yellow "package.json"} and {yellow "packages/*/package.json"}.
+  2. If using Pnpm Workspaces, read {yellow packages} from {yellow pnpm-workspace.yaml} in the root of the project.
+  3. If using Yarn Workspaces, read {yellow workspaces} from {yellow package.json}.
+  4. If using Lerna, read {yellow packages} from {yellow lerna.json}.
+  5. Default to {yellow "package.json"} and {yellow "packages/*/package.json"}.
 
 Reference:
   globs            {blue.underline https://github.com/isaacs/node-glob#glob-primer}
   lerna.json       {blue.underline https://github.com/lerna/lerna#lernajson}
   Yarn Workspaces  {blue.underline https://yarnpkg.com/lang/en/docs/workspaces}
+  Pnpm Workspaces  {blue.underline https://pnpm.js.org/en/workspaces}
 `);
 });
 

--- a/src/bin-list-mismatches.ts
+++ b/src/bin-list-mismatches.ts
@@ -29,14 +29,16 @@ Examples:
 
 Resolving Packages:
   1. If {yellow --source} globs are provided, use those.
-  2. If using Yarn Workspaces, read {yellow workspaces} from {yellow package.json}.
-  3. If using Lerna, read {yellow packages} from {yellow lerna.json}.
-  4. Default to {yellow "package.json"} and {yellow "packages/*/package.json"}.
+  2. If using Pnpm Workspaces, read {yellow packages} from {yellow pnpm-workspace.yaml} in the root of the project.
+  3. If using Yarn Workspaces, read {yellow workspaces} from {yellow package.json}.
+  4. If using Lerna, read {yellow packages} from {yellow lerna.json}.
+  5. Default to {yellow "package.json"} and {yellow "packages/*/package.json"}.
 
 Reference:
   globs            {blue.underline https://github.com/isaacs/node-glob#glob-primer}
   lerna.json       {blue.underline https://github.com/lerna/lerna#lernajson}
   Yarn Workspaces  {blue.underline https://yarnpkg.com/lang/en/docs/workspaces}
+  Pnpm Workspaces  {blue.underline https://pnpm.js.org/en/workspaces}
 `);
 });
 

--- a/src/bin-list.ts
+++ b/src/bin-list.ts
@@ -25,14 +25,16 @@ Examples:
 
 Resolving Packages:
   1. If {yellow --source} globs are provided, use those.
-  2. If using Yarn Workspaces, read {yellow workspaces} from {yellow package.json}.
-  3. If using Lerna, read {yellow packages} from {yellow lerna.json}.
-  4. Default to {yellow "package.json"} and {yellow "packages/*/package.json"}.
+  2. If using Pnpm Workspaces, read {yellow packages} from {yellow pnpm-workspace.yaml} in the root of the project.
+  3. If using Yarn Workspaces, read {yellow workspaces} from {yellow package.json}.
+  4. If using Lerna, read {yellow packages} from {yellow lerna.json}.
+  5. Default to {yellow "package.json"} and {yellow "packages/*/package.json"}.
 
 Reference:
   globs            {blue.underline https://github.com/isaacs/node-glob#glob-primer}
   lerna.json       {blue.underline https://github.com/lerna/lerna#lernajson}
   Yarn Workspaces  {blue.underline https://yarnpkg.com/lang/en/docs/workspaces}
+  Pnpm Workspaces  {blue.underline https://pnpm.js.org/en/workspaces}
 `);
 });
 

--- a/src/bin-set-semver-ranges.ts
+++ b/src/bin-set-semver-ranges.ts
@@ -43,14 +43,16 @@ Supported Ranges:
 
 Resolving Packages:
   1. If {yellow --source} globs are provided, use those.
-  2. If using Yarn Workspaces, read {yellow workspaces} from {yellow package.json}.
-  3. If using Lerna, read {yellow packages} from {yellow lerna.json}.
-  4. Default to {yellow "package.json"} and {yellow "packages/*/package.json"}.
+  2. If using Pnpm Workspaces, read {yellow packages} from {yellow pnpm-workspace.yaml} in the root of the project.
+  3. If using Yarn Workspaces, read {yellow workspaces} from {yellow package.json}.
+  4. If using Lerna, read {yellow packages} from {yellow lerna.json}.
+  5. Default to {yellow "package.json"} and {yellow "packages/*/package.json"}.
 
 Reference:
   globs            {blue.underline https://github.com/isaacs/node-glob#glob-primer}
   lerna.json       {blue.underline https://github.com/lerna/lerna#lernajson}
   Yarn Workspaces  {blue.underline https://yarnpkg.com/lang/en/docs/workspaces}
+  Pnpm Workspaces  {blue.underline https://pnpm.js.org/en/workspaces}
 `);
 });
 

--- a/src/commands/lib/get-wrappers.ts
+++ b/src/commands/lib/get-wrappers.ts
@@ -1,3 +1,4 @@
+import { getPackagesSync, Package } from '@manypkg/get-packages';
 import { readJsonSync } from 'fs-extra';
 import { sync } from 'glob';
 import { join, resolve } from 'path';
@@ -36,6 +37,18 @@ const getPatternsFromConfig = (fileName: string, propName: string): string[] | n
     : null;
 };
 
+const getPnpmPatterns = (): string[] | null => {
+  try {
+    const config = getPackagesSync(process.cwd());
+    const isNonEmptyArray = config && config.tool === 'pnpm' && config.packages.length > 0;
+    return isNonEmptyArray
+      ? [config.root].concat(config.packages).map((pkg: Package) => join(pkg.dir, 'package.json'))
+      : null;
+  } catch (e) {
+    return null;
+  }
+};
+
 const hasCliPatterns = (program: Options): boolean => program.sources && program.sources.length > 0;
 const getCliPatterns = (program: Options): Options['sources'] => program.sources;
 const getYarnPatterns = (): string[] | null => getPatternsFromConfig('package.json', 'workspaces');
@@ -46,7 +59,10 @@ const reduceFlatArray = (all: string[], next: string[]): string[] => all.concat(
 const createWrapper = (filePath: string): SourceWrapper => ({ contents: readJsonSync(filePath), filePath });
 
 export const getWrappers = (program: Options): SourceWrapper[] =>
-  (hasCliPatterns(program) ? getCliPatterns(program) : getYarnPatterns() || getLernaPatterns() || getDefaultPatterns())
+  (hasCliPatterns(program)
+    ? getCliPatterns(program)
+    : getPnpmPatterns() || getYarnPatterns() || getLernaPatterns() || getDefaultPatterns()
+  )
     .map(resolvePattern)
     .reduce(reduceFlatArray, [])
     .map(createWrapper);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,9 +2772,9 @@ lodash.sortby@^4.7.0:
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
 lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 make-dir@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
## Description (What)

This PR adds support for [pnpm](https://pnpm.js.org) workspaces. This was accomplished by using [get-packages](https://github.com/Thinkmill/manypkg/tree/master/packages/get-packages) to get the list of pnpm workspace packages.

Note that `get-packages` searches the directory hierarchy for the closest `pnpm-workspace.yaml` file, starting from the current working directory, so the behavior is a little different for pnpm than it is for npm/yarn. I would argue that being able to run `syncpack` from anywhere within a monorepo is actually a nice feature.

## Justification (Why)

pnpm is the "other" package manager which is already in heavy use by organizations like Microsoft and is growing in popularity. Many who use it say it has best-in-class support for monorepos. Thus it seemed natural to add pnpm support to syncpack. 

## How Can This Be Tested?

```sh
cd /path/to/some/dir
git clone https://github.com/JamieMason/syncpack.git
cd syncpack
npm run build
cd ..
git clone https://github.com/pnpm/pnpm.git
cd pnpm
git checkout acb74df703e29c0c340071d71d7687cbc7ff07af
node ../syncpack/dist/bin.js list | wc -l
# result should be 298
```
