### PR TITLE
Allow packages to have their own semver range rules

### DIFF
--- a/src/bin-list-mismatches.ts
+++ b/src/bin-list-mismatches.ts
@@ -49,6 +49,7 @@ program
   .option(...option.dev)
   .option(...option.peer)
   .option(...option.filter)
+  .option(...option.matchRanges)
   .parse(process.argv);
 
 listMismatchesFromDisk(
@@ -58,5 +59,6 @@ listMismatchesFromDisk(
     peer: program.opts().peer,
     prod: program.opts().prod,
     source: program.opts().source,
+    matchRanges: program.opts().matchRanges,
   }),
 );

--- a/src/commands/fix-mismatches.ts
+++ b/src/commands/fix-mismatches.ts
@@ -17,7 +17,8 @@ const getWorkspaceVersion = (name: string, wrappers: SourceWrapper[]): string | 
 };
 
 export const fixMismatches = (wrappers: SourceWrapper[], options: Options): void => {
-  const iterator = getMismatchedDependencies(wrappers, options);
+  // TODO: decide what to do here
+  const iterator = getMismatchedDependencies(wrappers, { ...options, matchRanges: false });
   const mismatches = Array.from(iterator).filter(matchesFilter(options));
 
   mismatches.forEach((installedPackage) => {

--- a/src/commands/lib/installations/get-grouped-mismatched-dependencies.ts
+++ b/src/commands/lib/installations/get-grouped-mismatched-dependencies.ts
@@ -1,6 +1,7 @@
 import { SyncpackConfig, VersionGroup } from '../../../constants';
 import { SourceWrapper } from '../get-wrappers';
 import { getDependencies, Installation, InstalledPackage } from './get-dependencies';
+import { versionsMatch } from './versions-match';
 
 const groupContainsDependency = (versionGroup: VersionGroup, installedPackage: InstalledPackage) =>
   versionGroup.dependencies.includes(installedPackage.name);
@@ -8,13 +9,15 @@ const groupContainsDependency = (versionGroup: VersionGroup, installedPackage: I
 const groupContainsPackage = (versionGroup: VersionGroup, installation: Installation) =>
   versionGroup.packages.includes(`${installation.source.contents.name}`);
 
-const hasDifferentVersionToPreviousSibling = (installation: Installation, i: number, all: Installation[]) =>
-  i > 0 && installation.version !== all[i - 1].version;
+const createHasDifferentVersionToPreviousSibling =
+  (matchRanges: boolean) => (installation: Installation, i: number, all: Installation[]) =>
+    !versionsMatch(installation, all[i - 1], matchRanges);
 
 export function* getGroupedMismatchedDependencies(
   wrappers: SourceWrapper[],
-  options: Pick<SyncpackConfig, 'dev' | 'peer' | 'prod' | 'versionGroups'>,
+  options: Pick<SyncpackConfig, 'dev' | 'peer' | 'prod' | 'matchRanges' | 'versionGroups'>,
 ): Generator<InstalledPackage> {
+  const hasDifferentVersionToPreviousSibling = createHasDifferentVersionToPreviousSibling(options.matchRanges);
   const iterator = getDependencies(wrappers, options);
   const installedPackages = Array.from(iterator);
 

--- a/src/commands/lib/installations/get-installations.ts
+++ b/src/commands/lib/installations/get-installations.ts
@@ -1,18 +1,18 @@
-import { getDependencies, Installation, } from './get-dependencies';
+import { getDependencies, Installation } from './get-dependencies';
 import { SyncpackConfig } from '../../../constants';
 import { SourceWrapper } from '../get-wrappers';
 import { matchesFilter as createMatchesFilter } from '../matches-filter';
 
 type Options = Pick<SyncpackConfig, 'dev' | 'peer' | 'prod' | 'filter'>;
 
-export function* getInstallations(wrappers: SourceWrapper[], options: Options): Generator<Installation>  {
+export function* getInstallations(wrappers: SourceWrapper[], options: Options): Generator<Installation> {
   const dependenciesIterator = getDependencies(wrappers, options);
   const matchesFilter = createMatchesFilter(options);
 
   for (const installedPackage of dependenciesIterator) {
     if (matchesFilter(installedPackage)) {
       for (const installation of installedPackage.installations) {
-        yield installation
+        yield installation;
       }
     }
   }

--- a/src/commands/lib/installations/get-mismatched-dependencies.ts
+++ b/src/commands/lib/installations/get-mismatched-dependencies.ts
@@ -2,10 +2,11 @@ import { SyncpackConfig } from '../../../constants';
 import { SourceWrapper } from '../get-wrappers';
 import { getDependencies, InstalledPackage } from './get-dependencies';
 import { getGroupedMismatchedDependencies } from './get-grouped-mismatched-dependencies';
+import { versionsMatch } from './versions-match';
 
 function* getUngroupedMismatchedDependencies(
   wrappers: SourceWrapper[],
-  options: Pick<SyncpackConfig, 'dev' | 'peer' | 'prod' | 'versionGroups'>,
+  options: Pick<SyncpackConfig, 'dev' | 'peer' | 'prod' | 'matchRanges' | 'versionGroups'>,
 ): Generator<InstalledPackage> {
   const iterator = getDependencies(wrappers, options);
   for (const installedPackage of iterator) {
@@ -13,7 +14,7 @@ function* getUngroupedMismatchedDependencies(
     const len = installations.length;
     if (len > 1) {
       for (let i = 1; i < len; i++) {
-        if (installations[i].version !== installations[i - 1].version) {
+        if (!versionsMatch(installations[i], installations[i - 1], options.matchRanges)) {
           yield installedPackage;
           break;
         }
@@ -24,7 +25,7 @@ function* getUngroupedMismatchedDependencies(
 
 export function* getMismatchedDependencies(
   wrappers: SourceWrapper[],
-  options: Pick<SyncpackConfig, 'dev' | 'peer' | 'prod' | 'versionGroups'>,
+  options: Pick<SyncpackConfig, 'dev' | 'peer' | 'prod' | 'matchRanges' | 'versionGroups'>,
 ): Generator<InstalledPackage> {
   const iterator = options.versionGroups.length
     ? getGroupedMismatchedDependencies(wrappers, options)

--- a/src/commands/lib/installations/versions-match.spec.ts
+++ b/src/commands/lib/installations/versions-match.spec.ts
@@ -46,6 +46,9 @@ describe('versionsMatch', () => {
       ['npm:1.2.3', 'npm:1.2.3', true],
       ['npm:1.2.3', 'npm:1.0.0', false],
       ['npm:1.2.3', 'github:1.2.3', false],
+
+      ['https://github.com/npm/npm.git', 'https://github.com/npm/npm.git', true],
+      ['https://github.com/npm/npm.git', 'https://github.com/npm/npm-two.git', false],
     ];
 
     it.each(cases)('%s =~ %s == %s', (aVersion, bVersion, expectedResult) => {

--- a/src/commands/lib/installations/versions-match.spec.ts
+++ b/src/commands/lib/installations/versions-match.spec.ts
@@ -1,0 +1,57 @@
+import { Installation } from './get-dependencies';
+import { versionsMatch } from './versions-match';
+
+const createInstallations = (name: string, ...versions: [string, string]) => ({
+  a: {
+    name,
+    version: versions[0],
+  } as Installation,
+  b: {
+    name,
+    version: versions[1],
+  } as Installation,
+});
+
+const expectVersionsMatchToReturn = (
+  a: Installation,
+  b: Installation,
+  matchRanges: boolean,
+  expectedResult: boolean,
+) => {
+  expect(versionsMatch(a, b, true)).toBe(expectedResult);
+  expect(versionsMatch(b, a, true)).toBe(expectedResult);
+};
+
+describe('versionsMatch', () => {
+  describe('matchRanges = true', () => {
+    const cases: Array<[a: string, b: string, expectedResult: boolean]> = [
+      ['1.2.3', '1.2.3', true],
+      ['1.2.3', '1.0.0', false],
+      ['1.2.3', '^1.2.3', true],
+      ['1.2.3', '^1.0.0', true],
+      ['1.2.3', '^2.0.0', false],
+      ['^1.2.3', '^1.2.3', true],
+      ['^1.2.3', '^1.4.5', true],
+      ['^1.2.3', '^2.0.0', false],
+      ['~1.2.3', '1.2.3', true],
+      ['~1.2.3', '1.2.4', true],
+      ['~1.2.3', '1.3.4', false],
+      ['~1.2.3', '1.0.0', false],
+      ['~1.2.3', '~1.2.3', true],
+      ['~1.2.3', '~1.3.4', false],
+      ['*', '1.3.4', true],
+      ['*', '^1.3.4', true],
+      ['*', '~1.3.4', true],
+
+      ['npm:1.2.3', 'npm:1.2.3', true],
+      ['npm:1.2.3', 'npm:1.0.0', false],
+      ['npm:1.2.3', 'github:1.2.3', false],
+    ];
+
+    it.each(cases)('%s =~ %s == %s', (aVersion, bVersion, expectedResult) => {
+      const { a, b } = createInstallations('fs', aVersion, bVersion);
+
+      expectVersionsMatchToReturn(a, b, true, expectedResult);
+    });
+  });
+});

--- a/src/commands/lib/installations/versions-match.ts
+++ b/src/commands/lib/installations/versions-match.ts
@@ -1,0 +1,31 @@
+import { Installation } from './get-dependencies';
+import { satisfies, intersects, validRange } from 'semver';
+
+const protocolRegex = /(\w+:)?(.+)/;
+const getProtocolAndVersion = (version: string): [version: string, protocol?: string] => {
+  const matches = protocolRegex.exec(version)!;
+
+  return [matches[2], matches[1]];
+};
+
+export const versionsMatch = (a: Installation, b: Installation, matchRanges: boolean): boolean => {
+  if (!matchRanges) return a.version === b.version;
+
+  let protocolsMatch = true;
+  const [aVersion, aProtocol] = getProtocolAndVersion(a.version);
+  const [bVersion, bProtocol] = getProtocolAndVersion(b.version);
+
+  if (aProtocol != null || bProtocol != null) {
+    protocolsMatch = aProtocol === bProtocol;
+  }
+
+  // If both versions are ranges we need to check if they intersect (satisfy each other)
+  // as .satisfies() does not support two ranges.
+  if (validRange(aVersion) && validRange(bVersion)) {
+    return protocolsMatch && intersects(aVersion, bVersion);
+  }
+
+  // We have to check both ways due to satisfies only working one way - range against version/range
+  // Otherwise it will fail if A is a version and B is a range
+  return protocolsMatch && (satisfies(aVersion, bVersion) || satisfies(bVersion, aVersion));
+};

--- a/src/commands/lib/installations/versions-match.ts
+++ b/src/commands/lib/installations/versions-match.ts
@@ -19,6 +19,10 @@ export const versionsMatch = (a: Installation, b: Installation, matchRanges: boo
     protocolsMatch = aProtocol === bProtocol;
   }
 
+  if (!validRange(aVersion) || !validRange(bVersion)) {
+    return aVersion === bVersion;
+  }
+
   // If both versions are ranges we need to check if they intersect (satisfy each other)
   // as .satisfies() does not support two ranges.
   if (validRange(aVersion) && validRange(bVersion)) {

--- a/src/commands/lib/set-semver-range.spec.ts
+++ b/src/commands/lib/set-semver-range.spec.ts
@@ -22,7 +22,9 @@ describe('setSemverRange', () => {
         expect(setSemverRange({ semverRange })('>=1.2.3')).toEqual(expected);
         expect(setSemverRange({ semverRange })('>1.2.3')).toEqual(expected);
         expect(setSemverRange({ semverRange })('*')).toEqual('*');
-        expect(setSemverRange({ semverRange })('https://github.com/npm/npm.git')).toEqual('https://github.com/npm/npm.git');
+        expect(setSemverRange({ semverRange })('https://github.com/npm/npm.git')).toEqual(
+          'https://github.com/npm/npm.git',
+        );
       });
     });
   });

--- a/src/commands/list-mismatches.ts
+++ b/src/commands/list-mismatches.ts
@@ -7,7 +7,7 @@ import { sortByName } from './lib/installations/sort-by-name';
 import { log } from './lib/log';
 import { matchesFilter } from './lib/matches-filter';
 
-type Options = Pick<SyncpackConfig, 'dev' | 'filter' | 'peer' | 'prod' | 'source' | 'versionGroups'>;
+type Options = Pick<SyncpackConfig, 'dev' | 'filter' | 'peer' | 'prod' | 'matchRanges' | 'source' | 'versionGroups'>;
 
 export const listMismatches = (wrappers: SourceWrapper[], options: Options): InstalledPackage[] => {
   const iterator = getMismatchedDependencies(wrappers, options);

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -7,7 +7,7 @@ import { sortByName } from './lib/installations/sort-by-name';
 import { log } from './lib/log';
 import { matchesFilter } from './lib/matches-filter';
 
-type Options = Pick<SyncpackConfig, 'dev' | 'filter' | 'peer' | 'prod' | 'source' | 'versionGroups'>;
+type Options = Pick<SyncpackConfig, 'dev' | 'filter' | 'peer' | 'prod' | 'matchRanges' | 'source' | 'versionGroups'>;
 
 export const list = (wrappers: SourceWrapper[], options: Options): void => {
   const packages = Array.from(getDependencies(wrappers, options)).filter(matchesFilter(options));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -65,6 +65,10 @@ export type SyncpackConfig = Readonly<{
    */
   prod: boolean;
   /**
+   * whether versions should be considered equal if their version ranges match
+   */
+  matchRanges: boolean;
+  /**
    * defaults to `""` to ensure that exact dependency versions are used instead
    * of loose ranges
    */
@@ -94,6 +98,7 @@ export const DEFAULT_CONFIG: SyncpackConfig = {
   indent: '  ',
   peer: true,
   prod: true,
+  matchRanges: false,
   semverRange: '',
   sortAz: ['contributors', 'dependencies', 'devDependencies', 'keywords', 'peerDependencies', 'resolutions', 'scripts'],
   sortFirst: ['name', 'description', 'version', 'author'],
@@ -112,6 +117,7 @@ interface OptionsByName {
   indent: [string, string];
   peer: [string, string];
   prod: [string, string];
+  matchRanges: [string, string];
   semverRange: [string, string];
   source: [string, string, typeof collect, string[]];
 }
@@ -122,6 +128,7 @@ export const option: OptionsByName = {
   indent: ['-i, --indent [value]', `override indentation. defaults to "${DEFAULT_CONFIG.indent}"`],
   peer: ['-P, --peer', 'include peerDependencies'],
   prod: ['-p, --prod', 'include dependencies'],
+  matchRanges: ['-m, --match-ranges', 'include dependencies'],
   semverRange: [
     '-r, --semver-range <range>',
     `see supported ranges below. defaults to "${DEFAULT_CONFIG.semverRange}"`,

--- a/src/lib/get-config.ts
+++ b/src/lib/get-config.ts
@@ -37,6 +37,7 @@ export const getConfig = (program: Partial<SyncpackConfig>): SyncpackConfig => {
     indent: getOption<string>('indent', (value: unknown): value is string => isNonEmptyString(value)),
     peer: hasTypeOverride ? Boolean(program.peer) : getOption<boolean>('peer', isBoolean),
     prod: hasTypeOverride ? Boolean(program.prod) : getOption<boolean>('prod', isBoolean),
+    matchRanges: getOption<boolean>('matchRanges', isBoolean),
     semverRange: getOption<ValidRange>('semverRange', isValidSemverRange),
     sortAz: getOption<string[]>('sortAz', isArrayOfStrings),
     sortFirst: getOption<string[]>('sortFirst', isArrayOfStrings),


### PR DESCRIPTION
## Description (What)

This PR adds an option that changes the version check in `list-matches` from a strict equal check to a semver match.

i.e.

```
               1.2.3 == ^1.0.0 == false
--match-ranges 1.2.3 =~ ^1.0.0 == true
```

## Justification (Why)

A general rule for dependencies is that if you have a library you want version ranges, and for applications you want plain/pinned versions.

In monorepos you might have both packages and applications, depending on the same packages but with differing ranges. This will result in errors when using `list-mismatches`.

![image](https://user-images.githubusercontent.com/472500/136024987-f7bb8f00-9775-4b20-9536-b51f77f55666.png)

This PR allows using `list-mismatches` in those.

## How Can This Be Tested?

Requires pnpm, can be handled by enabling [`corepack`](https://nodejs.org/api/corepack.html) or just using `npm i -g pnpm`

1. Check out this PR, build it
1. Check out https://github.com/BeeeQueue/syncpack-match-test, run `pnpm i` in it
1. Run `pnpm syncpack list-mismatches` - see errors
1. Run `pnpm link {path to syncpack dir}`
1. Run `pnpm syncpack list-mismatches -m` - see no errors
