### PR TITLE
fix: ignore node_modules

### DIFF
--- a/src/lib/disk.ts
+++ b/src/lib/disk.ts
@@ -10,7 +10,7 @@ export type Disk = typeof disk;
 
 export const disk = {
   globSync(pattern: string): string[] {
-    return globSync(pattern, { absolute: true, cwd: CWD });
+    return globSync(pattern, { ignore: '**/node_modules/**', absolute: true, cwd: CWD });
   },
   readConfigFileSync(): Partial<SyncpackConfig> {
     const rcSearch = cosmiconfigSync('syncpack').search();


### PR DESCRIPTION
## Description (What)

This PR fixes #68

## Justification (Why)

Monorepos with `yarn` and `pnpm` workspaces allow package locations to be defined using a glob pattern such as `packages/**` to allow for a deep package tree.

Syncpack uses these patterns to search for any `package.json` files. However, some of these packages may have their own `node_modules` folder and currently Syncpack will discover `package.json` files within these:

```
.
├── ...
├── packages                   
│   └── tools
│       ├── firsttool 
│       │   ├── node_modules
│       │   │    └──  some_dependency
│       │   │         ├── ...
│       │   │         └──  package.json  <--- will be picked up by Syncpack
│       │   ├── ...
│       │   └── package.json
│       ├── second tool
│       │   └── ...
│       └── ...
└── ...
```

This results in version mismatches due to vendor dependencies deep within the tree.

This PR adds an ignore pattern to glob, which simply excludes any `node_modules` folders.

