### PR TITLE
feat: add config path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See [`versionGroups`](#versiongroups) if you have advanced requirements.
 -o, --overrides         include overrides (pnpm)
 -f, --filter [pattern]  only include dependencies whose name matches this regex
 -i, --indent [value]    override indentation. defaults to "  "
+-c, --config <path>     path to a syncpack config file
 -h, --help              display help for command
 ```
 
@@ -76,6 +77,7 @@ Shorthand properties are used where available, such as the `"repository"` and
 ```
 -s, --source [pattern]  glob pattern for package.json files to read from
 -i, --indent [value]    override indentation. defaults to "  "
+-c, --config <path>     path to a syncpack config file
 -h, --help              output usage information
 ```
 
@@ -116,6 +118,7 @@ See [`semverGroups`](#semvergroups) if you have advanced requirements.
 -o, --overrides             include overrides (pnpm)
 -f, --filter [pattern]      only include dependencies whose name matches this regex
 -r, --semver-range <range>  see supported ranges below. defaults to ""
+-c, --config <path>         path to a syncpack config file
 -h, --help                  display help for command
 ```
 
@@ -158,6 +161,7 @@ List all dependencies required by your packages.
 -R, --resolutions       include resolutions (yarn)
 -o, --overrides         include overrides (pnpm)
 -f, --filter [pattern]  only include dependencies whose name matches this regex
+-c, --config <path>     path to a syncpack config file
 -h, --help              display help for command
 ```
 
@@ -201,6 +205,7 @@ See [`versionGroups`](#versiongroups) if you have advanced requirements.
 -R, --resolutions       include resolutions (yarn)
 -o, --overrides         include overrides (pnpm)
 -f, --filter [pattern]  only include dependencies whose name matches this regex
+-c, --config <path>     path to a syncpack config file
 -h, --help              display help for command
 ```
 
@@ -246,6 +251,7 @@ See [`semverGroups`](#semvergroups) if you have advanced requirements.
 -f, --filter [pattern]      only include dependencies whose name matches this regex
 -i, --indent [value]        override indentation. defaults to "  "
 -r, --semver-range <range>  see supported ranges below. defaults to ""
+-c, --config <path>         path to a syncpack config file
 -h, --help                  display help for command
 ```
 
@@ -286,6 +292,9 @@ tree in the following places:
   or `.syncpackrc.cjs` file
 - a `syncpack.config.js` or `syncpack.config.cjs` CommonJS module exporting an
   object
+
+If you want to specify a path to a configuration file, overriding the discovered
+configuration file (if present), you can use the `--config` option.
 
 ### Default Configuration
 

--- a/src/bin-fix-mismatches/fix-mismatches.spec.ts
+++ b/src/bin-fix-mismatches/fix-mismatches.spec.ts
@@ -28,7 +28,7 @@ describe('fixMismatches', () => {
             return bBefore.json;
           }
         });
-        fixMismatches(getInput(disk, {}), disk);
+        fixMismatches(getInput(disk, undefined, {}), disk);
         expect(disk.writeFileSync.mock.calls).toEqual([
           [expect.stringContaining('packages/a/package.json'), aAfter.json],
         ]);
@@ -75,7 +75,7 @@ describe('fixMismatches', () => {
           if (filePath.endsWith('packages/foo/package.json'))
             return fooBefore.json;
         });
-        fixMismatches(getInput(disk, {}), disk);
+        fixMismatches(getInput(disk, undefined, {}), disk);
         expect(disk.writeFileSync.mock.calls).toEqual([
           [expect.stringContaining('packages/a/package.json'), aAfter.json],
           [expect.stringContaining('packages/b/package.json'), bAfter.json],
@@ -126,7 +126,7 @@ describe('fixMismatches', () => {
         if (filePath.endsWith('packages/c/package.json')) return cBefore.json;
         if (filePath.endsWith('packages/d/package.json')) return dBefore.json;
       });
-      fixMismatches(getInput(disk, {}), disk);
+      fixMismatches(getInput(disk, undefined, {}), disk);
       expect(disk.writeFileSync.mock.calls).toEqual([
         [expect.stringContaining('packages/a/package.json'), aAfter.json],
         [expect.stringContaining('packages/b/package.json'), bAfter.json],

--- a/src/bin-fix-mismatches/index.ts
+++ b/src/bin-fix-mismatches/index.ts
@@ -59,10 +59,11 @@ program
   .option(...option.overrides)
   .option(...option.filter)
   .option(...option.indent)
+  .option(...option.config)
   .parse(process.argv);
 
 fixMismatches(
-  getInput(disk, {
+  getInput(disk, program.opts().config, {
     dev: program.opts().dev,
     filter: program.opts().filter,
     indent: program.opts().indent,

--- a/src/bin-format/index.ts
+++ b/src/bin-format/index.ts
@@ -45,10 +45,11 @@ Reference:
 program
   .option(...option.source)
   .option(...option.indent)
+  .option(...option.config)
   .parse(process.argv);
 
 format(
-  getInput(disk, {
+  getInput(disk, program.opts().config, {
     indent: program.opts().indent,
     overrides: program.opts().overrides,
     resolutions: program.opts().resolutions,

--- a/src/bin-lint-semver-ranges/index.ts
+++ b/src/bin-lint-semver-ranges/index.ts
@@ -68,10 +68,11 @@ program
   .option(...option.overrides)
   .option(...option.filter)
   .option(...option.semverRange)
+  .option(...option.config)
   .parse(process.argv);
 
 lintSemverRanges(
-  getInput(disk, {
+  getInput(disk, program.opts().config, {
     dev: program.opts().dev,
     filter: program.opts().filter,
     overrides: program.opts().overrides,

--- a/src/bin-list-mismatches/index.ts
+++ b/src/bin-list-mismatches/index.ts
@@ -52,10 +52,11 @@ program
   .option(...option.resolutions)
   .option(...option.overrides)
   .option(...option.filter)
+  .option(...option.config)
   .parse(process.argv);
 
 listMismatches(
-  getInput(disk, {
+  getInput(disk, program.opts().config, {
     dev: program.opts().dev,
     filter: program.opts().filter,
     overrides: program.opts().overrides,

--- a/src/bin-list/index.ts
+++ b/src/bin-list/index.ts
@@ -48,10 +48,11 @@ program
   .option(...option.resolutions)
   .option(...option.overrides)
   .option(...option.filter)
+  .option(...option.config)
   .parse(process.argv);
 
 list(
-  getInput(disk, {
+  getInput(disk, program.opts().config, {
     dev: program.opts().dev,
     filter: program.opts().filter,
     overrides: program.opts().overrides,

--- a/src/bin-set-semver-ranges/index.ts
+++ b/src/bin-set-semver-ranges/index.ts
@@ -71,10 +71,11 @@ program
   .option(...option.filter)
   .option(...option.indent)
   .option(...option.semverRange)
+  .option(...option.config)
   .parse(process.argv);
 
 setSemverRanges(
-  getInput(disk, {
+  getInput(disk, program.opts().config, {
     dev: program.opts().dev,
     filter: program.opts().filter,
     indent: program.opts().indent,

--- a/src/bin-set-semver-ranges/set-semver-ranges.spec.ts
+++ b/src/bin-set-semver-ranges/set-semver-ranges.spec.ts
@@ -19,7 +19,7 @@ describe('setSemverRanges', () => {
       if (filePath.endsWith('packages/a/package.json')) return aBefore.json;
     });
     setSemverRanges(
-      getInput(disk, {
+      getInput(disk, undefined, {
         dev: false,
         peer: false,
         prod: true,

--- a/src/lib/disk.ts
+++ b/src/lib/disk.ts
@@ -10,10 +10,16 @@ export type Disk = typeof disk;
 
 export const disk = {
   globSync(pattern: string): string[] {
-    return globSync(pattern, { ignore: '**/node_modules/**', absolute: true, cwd: CWD });
+    return globSync(pattern, {
+      ignore: '**/node_modules/**',
+      absolute: true,
+      cwd: CWD,
+    });
   },
-  readConfigFileSync(): Partial<SyncpackConfig> {
-    const rcSearch = cosmiconfigSync('syncpack').search();
+  readConfigFileSync(configFile: string | undefined): Partial<SyncpackConfig> {
+    const rcSearch = configFile
+      ? cosmiconfigSync('syncpack').load(configFile)
+      : cosmiconfigSync('syncpack').search();
     const rcConfig: unknown = rcSearch !== null ? rcSearch.config : {};
     const rcFile = isObject<Partial<SyncpackConfig>>(rcConfig) ? rcConfig : {};
     return rcFile;

--- a/src/lib/get-input/get-input.spec.ts
+++ b/src/lib/get-input/get-input.spec.ts
@@ -13,41 +13,43 @@ describe('getInput', () => {
     const resolutions = 'resolutions';
 
     it('enables them all if none are set', () => {
-      expect(getInput(disk, {})).toHaveProperty(
+      expect(getInput(disk, undefined, {})).toHaveProperty(
         'dependencyTypes',
         expect.arrayContaining([prod, dev, peer, overrides, resolutions]),
       );
     });
     it('enables one if it is the only one set', () => {
-      expect(getInput(disk, { prod: true })).toHaveProperty('dependencyTypes', [
-        prod,
-      ]);
-      expect(getInput(disk, { dev: true })).toHaveProperty('dependencyTypes', [
-        dev,
-      ]);
-      expect(getInput(disk, { peer: true })).toHaveProperty('dependencyTypes', [
-        peer,
-      ]);
-      expect(getInput(disk, { overrides: true })).toHaveProperty(
+      expect(getInput(disk, undefined, { prod: true })).toHaveProperty(
+        'dependencyTypes',
+        [prod],
+      );
+      expect(getInput(disk, undefined, { dev: true })).toHaveProperty(
+        'dependencyTypes',
+        [dev],
+      );
+      expect(getInput(disk, undefined, { peer: true })).toHaveProperty(
+        'dependencyTypes',
+        [peer],
+      );
+      expect(getInput(disk, undefined, { overrides: true })).toHaveProperty(
         'dependencyTypes',
         [overrides],
       );
-      expect(getInput(disk, { resolutions: true })).toHaveProperty(
+      expect(getInput(disk, undefined, { resolutions: true })).toHaveProperty(
         'dependencyTypes',
         [resolutions],
       );
     });
     it('enables some if only those are set', () => {
-      expect(getInput(disk, { dev: true, prod: true })).toHaveProperty(
-        'dependencyTypes',
-        expect.arrayContaining([prod, dev]),
-      );
+      expect(
+        getInput(disk, undefined, { dev: true, prod: true }),
+      ).toHaveProperty('dependencyTypes', expect.arrayContaining([prod, dev]));
     });
   });
   describe('source', () => {
     it('uses defaults when no CLI options or config are set', () => {
       const disk = mockDisk();
-      expect(getInput(disk, {})).toHaveProperty(
+      expect(getInput(disk, undefined, {})).toHaveProperty(
         'source',
         DEFAULT_CONFIG.source,
       );
@@ -55,19 +57,20 @@ describe('getInput', () => {
     it('uses value from config when no CLI options are set', () => {
       const disk = mockDisk();
       disk.readConfigFileSync.mockReturnValue({ source: ['./foo'] });
-      expect(getInput(disk, {})).toHaveProperty('source', ['./foo']);
+      expect(getInput(disk, undefined, {})).toHaveProperty('source', ['./foo']);
     });
     it('uses value from CLI when config and CLI options are set', () => {
       const disk = mockDisk();
       disk.readConfigFileSync.mockReturnValue({ source: ['./foo'] });
-      expect(getInput(disk, { source: ['./bar'] })).toHaveProperty('source', [
-        './bar',
-      ]);
+      expect(getInput(disk, undefined, { source: ['./bar'] })).toHaveProperty(
+        'source',
+        ['./bar'],
+      );
     });
     it('combines defaults, values from CLI options, and config', () => {
       const disk = mockDisk();
       disk.readConfigFileSync.mockReturnValue({ source: ['./foo'] });
-      expect(getInput(disk, { sortAz: ['overridden'] })).toEqual(
+      expect(getInput(disk, undefined, { sortAz: ['overridden'] })).toEqual(
         expect.objectContaining({
           semverRange: '',
           source: ['./foo'],
@@ -87,20 +90,20 @@ describe('getInput', () => {
             },
           ],
         });
-        expect(getInput(disk, { sortAz: ['overridden'] }).semverGroups).toEqual(
-          [
-            expect.objectContaining({
-              dependencies: ['@alpha/*'],
-              packages: ['@myrepo/library'],
-              range: '~',
-            }),
-            expect.objectContaining({
-              dependencies: ['**'],
-              packages: ['**'],
-              range: '',
-            }),
-          ],
-        );
+        expect(
+          getInput(disk, undefined, { sortAz: ['overridden'] }).semverGroups,
+        ).toEqual([
+          expect.objectContaining({
+            dependencies: ['@alpha/*'],
+            packages: ['@myrepo/library'],
+            range: '~',
+          }),
+          expect.objectContaining({
+            dependencies: ['**'],
+            packages: ['**'],
+            range: '',
+          }),
+        ]);
       });
       it('merges versionGroups', () => {
         const disk = mockDisk();
@@ -110,7 +113,7 @@ describe('getInput', () => {
           ],
         });
         expect(
-          getInput(disk, { sortAz: ['overridden'] }).versionGroups,
+          getInput(disk, undefined, { sortAz: ['overridden'] }).versionGroups,
         ).toEqual([
           expect.objectContaining({
             dependencies: ['chalk'],
@@ -135,7 +138,9 @@ describe('getInput', () => {
           const disk = mockDisk();
           disk.globSync.mockReturnValue([filePath]);
           disk.readFileSync.mockReturnValue(json);
-          expect(getInput(disk, { source: ['package.json'] })).toEqual(
+          expect(
+            getInput(disk, undefined, { source: ['package.json'] }),
+          ).toEqual(
             expect.objectContaining({
               wrappers: [{ filePath, contents, json }],
             }),
@@ -146,10 +151,9 @@ describe('getInput', () => {
         it('returns an empty array', () => {
           const disk = mockDisk();
           disk.globSync.mockReturnValue([]);
-          expect(getInput(disk, { source: ['typo.json'] })).toHaveProperty(
-            'wrappers',
-            [],
-          );
+          expect(
+            getInput(disk, undefined, { source: ['typo.json'] }),
+          ).toHaveProperty('wrappers', []);
           expect(disk.readFileSync).not.toHaveBeenCalled();
         });
       });
@@ -157,7 +161,7 @@ describe('getInput', () => {
     describe('when no --source cli options are given', () => {
       it('performs a default search', () => {
         const disk = mockDisk();
-        getInput(disk, {});
+        getInput(disk, undefined, {});
         expect(disk.globSync.mock.calls).toEqual([
           ['package.json'],
           ['packages/*/package.json'],
@@ -173,7 +177,7 @@ describe('getInput', () => {
             const disk = mockDisk();
             disk.globSync.mockReturnValue([filePath]);
             disk.readFileSync.mockReturnValue(json);
-            getInput(disk, {});
+            getInput(disk, undefined, {});
             expect(disk.globSync.mock.calls).toEqual([
               ['package.json'],
               ['as-array/*/package.json'],
@@ -189,7 +193,7 @@ describe('getInput', () => {
             const disk = mockDisk();
             disk.globSync.mockReturnValue([filePath]);
             disk.readFileSync.mockReturnValue(json);
-            getInput(disk, {});
+            getInput(disk, undefined, {});
             expect(disk.globSync.mock.calls).toEqual([
               ['package.json'],
               ['as-object/*/package.json'],
@@ -211,7 +215,7 @@ describe('getInput', () => {
               if (filePath.endsWith('lerna.json'))
                 return JSON.stringify({ packages: ['lerna/*'] });
             });
-            getInput(disk, {});
+            getInput(disk, undefined, {});
             expect(disk.globSync.mock.calls).toEqual([
               ['package.json'],
               ['lerna/*/package.json'],
@@ -228,7 +232,7 @@ describe('getInput', () => {
               disk.readYamlFileSync.mockReturnValue({
                 packages: ['./from-pnpm/*'],
               });
-              getInput(disk, {});
+              getInput(disk, undefined, {});
               expect(disk.globSync.mock.calls).toEqual([
                 ['package.json'],
                 ['from-pnpm/*/package.json'],

--- a/src/lib/get-input/index.ts
+++ b/src/lib/get-input/index.ts
@@ -18,13 +18,15 @@ export type ProgramInput = SyncpackConfig & {
  * that the majority of syncpack and its tests don't have to deal with the file
  * system and can focus solely on transformation logic.
  *
- * @param  program  Options received from CLI arguments
+ * @param  configPath  Path to config file, or undefined to search for one
+ * @param  program     Options received from CLI arguments
  */
 export function getInput(
   disk: Disk,
+  configPath: string | undefined,
   program: Partial<SyncpackConfig>,
 ): ProgramInput {
-  const rcFile = disk.readConfigFileSync();
+  const rcFile = disk.readConfigFileSync(configPath);
   const config = getConfig(rcFile, program);
   const wrappers = getWrappers(disk, config);
   const instances = getInstances(config, wrappers);

--- a/src/option.ts
+++ b/src/option.ts
@@ -3,6 +3,7 @@ import { collect } from './lib/collect';
 import { DEFAULT_CONFIG } from './constants';
 
 export const option = {
+  config: ['-c, --config <path>', 'path to a syncpack config file'],
   dev: ['-d, --dev', chalk`include {yellow devDependencies}`],
   filter: [
     '-f, --filter [pattern]',


### PR DESCRIPTION
## Description (What)

Adds a CLI option of `--config`, that optionally allows a path to a configuration file to be specified.

Closes #71

## Justification (Why)

Other tools, such as ESLint and Prettier, allow the user to specific a configuration path other than the normal one auto-detected. This can be useful for i.e. moving the config files out of the package root and into a `config/` folder. Allowing a custom config path brings `syncpack` into parity with these tools.

## How Can This Be Tested?

Create a new `syncpack` config file i.e. `configs/syncpack.json`

```
syncpack --config configs/syncpack.json
syncpack format --config configs/syncpack.json
```