### PR TITLE
fix(format): don't transform 'repository' property when it has a child 'directory' property

### DIFF
--- a/src/bin-format/format.spec.ts
+++ b/src/bin-format/format.spec.ts
@@ -117,6 +117,27 @@ describe('format', () => {
       expect.stringContaining(normalize('some/package.json')),
     );
   });
+  it('retains long form format for "repository" when directory property used', () => {
+    const disk = mockDisk();
+    const before = {
+      repository: {
+        url: 'git://gitlab.com/User/repo',
+        type: 'git',
+        directory: 'packages/foo',
+      },
+    };
+    const input = {
+      ...DEFAULT_CONFIG,
+      wrappers: [createWrapper(before)],
+    } as ProgramInput;
+    const log = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    format(input, disk);
+    expect(disk.writeFileSync).not.toHaveBeenCalledWith();
+    expect(log).toHaveBeenCalledWith(
+      expect.stringMatching(/-/),
+      expect.stringContaining(normalize('some/package.json')),
+    );
+  });
   it('uses github shorthand format for "repository"', () => {
     const disk = mockDisk();
     const before = {

--- a/src/bin-format/format.ts
+++ b/src/bin-format/format.ts
@@ -18,7 +18,7 @@ export function format(input: ProgramInput, disk: Disk): void {
       contents.bugs = bugsUrl;
     }
 
-    if (repositoryUrl) {
+    if (repositoryUrl && optionalChaining?.repository?.directory == null) {
       contents.repository = repositoryUrl.includes('github.com')
         ? repositoryUrl.replace(/^.+github\.com\//, '')
         : repositoryUrl;


### PR DESCRIPTION
Closes #91

## Description (What)

This PR modifies the "format" command to prevent it from formatting the `repository` property when its value is an object that has a `directory` property.

## Justification (Why)

When a package exists in a mono-repo its `repository` property can have a [`directory`](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository) property to denote its location within the repo. Currently syncpack will transform the repository property to its shortform version, but this ignores the directory property.

## How Can This Be Tested?

Set up a `package.json` that has a `repository` property with the value of:

```json
{
  "url": "git://gitlab.com/User/repo",
  "type": "git"
}
```

Run the "format" command and observe that it converts to shortform.

Now, change its value to the following:

```json
{
  "url": "git://gitlab.com/User/repo",
  "type": "git",
  "directory": "packages/foo"
}
```

Run the command again and observe that this property is not modified.