### PR TITLE
fix versionGroup.dependencyTypes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ used in `dependencies` or `devDependencies`.
   "versionGroups": [
     {
       "dependencies": ["**"],
-      "dependencyTypes": ["peer"],
+      "dependencyTypes": ["peerDependencies"],
       "packages": ["**"]
     }
   ]


### PR DESCRIPTION
Fixes https://github.com/JamieMason/syncpack/issues/96

## Description (What)

<!--
Add context so reviewers understand what it is they're looking at. Describe what
this change does and what was required to deliver it. This section also helps
those who might need to modify your code at a time when you're not available,
and need help understanding it in order to get started.
-->

The example for `versionGroup.dependencyTypes` says `peer` where it should say `peerDependencies`

## Justification (Why)

<!--
Describe why this change is required, what problem it solves, and what
alternatives exist that you might have considered. This helps reviewers
understand the value of this change, or to highlight unnecessary changes which
can be avoided.
-->

Valid dependencyTypes: https://github.com/JamieMason/syncpack/blob/c6db8786f9a117eb9d1d334edc7dfa70b036eeaf/src/constants.ts#L1-L8

## How Can This Be Tested?

<!--
Bullet-list how reviewers can install, build, test, and run your changes.
-->
