### PR TITLE
Fix default source overriding config file

### DIFF
--- a/src/get-context/get-config/get-config.spec.ts
+++ b/src/get-context/get-config/get-config.spec.ts
@@ -140,7 +140,7 @@ describe('semverRange', () => {
 });
 
 describe('source', () => {
-  it('uses default when not set', () => {
+  it('defaults to [] when not set', () => {
     const disk = mockDisk();
     const config = getConfig(disk, {});
     expect(R.getExn(config).source).toEqual([]);

--- a/src/get-context/get-config/index.ts
+++ b/src/get-context/get-config/index.ts
@@ -42,7 +42,7 @@ function unSafeGetConfig(
     semverRange: getConfigByName('semverRange'),
     sortAz: getConfigByName('sortAz'),
     sortFirst: getConfigByName('sortFirst'),
-    source: getConfigByName('source'),
+    source: getConfigByName('source', []),
     types: fromCli?.types,
     versionGroups: getConfigByName('versionGroups'),
   });
@@ -78,10 +78,12 @@ function unSafeGetConfig(
 
   return allConfig;
 
-  function getConfigByName(name: keyof Syncpack.Config.Public): unknown {
+  function getConfigByName(name: keyof Syncpack.Config.Public, defaultValue?: any): unknown {
     if (typeof (fromCli as any)[name] !== 'undefined')
       return (fromCli as Syncpack.Config.Public)[name];
     if (typeof (fromRcFile as any)[name] !== 'undefined')
       return (fromRcFile as Syncpack.Config.Public)[name];
+    if (defaultValue)
+      return defaultValue
   }
 }

--- a/src/option.ts
+++ b/src/option.ts
@@ -19,7 +19,6 @@ export const option = {
     '-s, --source [pattern]',
     'glob pattern for package.json files to read from',
     collect,
-    [] as string[],
   ],
   types: [
     '-t, --types <names>',


### PR DESCRIPTION
## Description (What)

Because the `source` property was being defaulted to `[]` on the CLI, this code would never allow the config file to override the default value.

src/get-context/get-config/index.ts:81
```js
function getConfigByName(name: keyof Syncpack.Config.Public, defaultValue?: any): unknown {
    if (typeof (fromCli as any)[name] !== 'undefined')
      return (fromCli as Syncpack.Config.Public)[name];
    if (typeof (fromRcFile as any)[name] !== 'undefined')
      return (fromRcFile as Syncpack.Config.Public)[name];
}
```

Essentially, `fromCli` is always set, so the `fromRcFile` is never even looked at. 

<!--
Add context so reviewers understand what it is they're looking at. Describe what
this change does and what was required to deliver it. This section also helps
those who might need to modify your code at a time when you're not available,
and need help understanding it in order to get started.
-->
I think the best way to fix this is to allow `getConfig()` from that file to return a default value if nothing is set. Not sure if that's the best place to put this, but it at least puts the default where every part of the code will pull it from

## Justification (Why)
It would be nice if the documentation about the configuration file actually worked the way it says it will
<!--
Describe why this change is required, what problem it solves, and what
alternatives exist that you might have considered. This helps reviewers
understand the value of this change, or to highlight unnecessary changes which
can be avoided.
-->

## How Can This Be Tested?
This test was incorrect. 
`src/get-context/get-config/get-config.spec.ts:156-161` 
```js
it('uses config value when set', () => {
    const disk = mockDisk();
    disk.readConfigFileSync.mockReturnValue({ source: ['projects/*'] });
    const config = getConfig(disk, {});
    expect(R.getExn(config).source).toEqual(['projects/*']);
  });
```

`const config = getConfig(disk, {})` was an incorrect state.

* In a branch that doesn't have these changes, set it to the correct state `const config = getConfig(disk, { source: [] })`
** You'll see that it throws an error
* Switch to this branch and the error goes away.

<!--
Bullet-list how reviewers can install, build, test, and run your changes.
-->
