### PR TITLE
Fix broken semverGroups dependencyTypes example

### DIFF
--- a/site/docs/config/semver-groups.mdx
+++ b/site/docs/config/semver-groups.mdx
@@ -70,7 +70,7 @@ and peer dependencies can be broader.
     {
       "range": "",
       "dependencyTypes": [
-        "dependencies",
+        "prod",
         "resolutions",
         "overrides",
         "pnpmOverrides",

--- a/site/docs/config/semver-groups.mdx
+++ b/site/docs/config/semver-groups.mdx
@@ -81,13 +81,13 @@ and peer dependencies can be broader.
     },
     {
       "range": "~",
-      "dependencyTypes": ["devDependencies"],
+      "dependencyTypes": ["dev"],
       "dependencies": ["**"],
       "packages": ["**"]
     },
     {
       "range": "^",
-      "dependencyTypes": ["peerDependencies"],
+      "dependencyTypes": ["peer"],
       "dependencies": ["**"],
       "packages": ["**"]
     }


### PR DESCRIPTION
The example was broken, as `devDependencies` and `peerDependencies` should be referenced in `dependencyTypes` using `dev` and `peer` respectively.

See https://jamiemason.github.io/syncpack/config/version-groups#dependencytypes-string