### PR TITLE
Add a JSON schema

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -32,7 +32,6 @@ npm test
 - [commander](https://ghub.io/commander): the complete solution for node.js command-line programs
 - [cosmiconfig](https://ghub.io/cosmiconfig): Find and load configuration from a package.json property, rc file, or CommonJS module
 - [enquirer](https://ghub.io/enquirer): Stylish, intuitive and user-friendly prompt system. Fast and lightweight enough for small projects, powerful and extensible enough for the most advanced use cases.
-- [fs-extra](https://ghub.io/fs-extra): fs-extra contains methods that aren&#39;t included in the vanilla Node.js fs package. Such as recursive mkdir, copy, and remove.
 - [globby](https://ghub.io/globby): User-friendly glob matching
 - [minimatch](https://ghub.io/minimatch): a glob matcher in javascript
 - [ora](https://ghub.io/ora): Elegant terminal spinner
@@ -45,7 +44,6 @@ npm test
 ## Dev Dependencies
 
 - [@tsconfig/node18](https://ghub.io/@tsconfig/node18): A base TSConfig for working with Node 18.
-- [@types/fs-extra](https://ghub.io/@types/fs-extra): TypeScript definitions for fs-extra
 - [@types/jest](https://ghub.io/@types/jest): TypeScript definitions for Jest
 - [@types/node](https://ghub.io/@types/node): TypeScript definitions for Node.js
 - [@types/prompts](https://ghub.io/@types/prompts): TypeScript definitions for prompts

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "commander": "11.0.0",
     "cosmiconfig": "8.2.0",
     "enquirer": "2.3.6",
-    "fs-extra": "11.1.1",
     "globby": "11.1.0",
     "minimatch": "9.0.2",
     "ora": "5.4.1",
@@ -51,7 +50,6 @@
   },
   "devDependencies": {
     "@tsconfig/node18": "18.2.0",
-    "@types/fs-extra": "11.0.1",
     "@types/jest": "29.5.2",
     "@types/node": "14.18.36",
     "@types/prompts": "2.4.4",
@@ -114,8 +112,9 @@
     "lint": "yarn lint:ts && yarn lint:eslint",
     "lint:eslint": "eslint --ext .ts .",
     "lint:ts": "tsc --noEmit --project tsconfig.json",
-    "prepack": "yarn build",
-    "test": "jest src test"
+    "prepack": "yarn build && yarn schema",
+    "test": "jest src test",
+    "schema": "ts-json-schema-generator --path ./src/index.ts --type RcFile -o schema.json"
   },
   "types": "dist/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "prettier": "2.8.8",
     "rimraf": "5.0.1",
     "ts-jest": "29.1.1",
+    "ts-json-schema-generator": "1.2.0",
     "ts-node": "10.9.1",
     "typescript": "5.1.6"
   },

--- a/schema.json
+++ b/schema.json
@@ -151,6 +151,16 @@
       "type": "object"
     },
     "SemverGroupConfig.Any": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SemverGroupConfig.Ignored"
+        },
+        {
+          "$ref": "#/definitions/SemverGroupConfig.WithRange"
+        }
+      ]
+    },
+    "SemverGroupConfig.Ignored": {
       "additionalProperties": false,
       "properties": {
         "dependencies": {
@@ -177,6 +187,38 @@
             "type": "string"
           },
           "type": "array"
+        }
+      },
+      "required": [
+        "dependencies",
+        "isIgnored",
+        "packages"
+      ],
+      "type": "object"
+    },
+    "SemverGroupConfig.WithRange": {
+      "additionalProperties": false,
+      "properties": {
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dependencyTypes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "label": {
+          "type": "string"
+        },
+        "packages": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "range": {
           "$ref": "#/definitions/SemverRange"
@@ -184,7 +226,8 @@
       },
       "required": [
         "dependencies",
-        "packages"
+        "packages",
+        "range"
       ],
       "type": "object"
     },
@@ -205,6 +248,28 @@
       "type": "string"
     },
     "VersionGroupConfig.Any": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/VersionGroupConfig.Banned"
+        },
+        {
+          "$ref": "#/definitions/VersionGroupConfig.Ignored"
+        },
+        {
+          "$ref": "#/definitions/VersionGroupConfig.Pinned"
+        },
+        {
+          "$ref": "#/definitions/VersionGroupConfig.SameRange"
+        },
+        {
+          "$ref": "#/definitions/VersionGroupConfig.SnappedTo"
+        },
+        {
+          "$ref": "#/definitions/VersionGroupConfig.Standard"
+        }
+      ]
+    },
+    "VersionGroupConfig.Banned": {
       "additionalProperties": false,
       "properties": {
         "dependencies": {
@@ -223,6 +288,38 @@
           "const": true,
           "type": "boolean"
         },
+        "label": {
+          "type": "string"
+        },
+        "packages": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "dependencies",
+        "isBanned",
+        "packages"
+      ],
+      "type": "object"
+    },
+    "VersionGroupConfig.Ignored": {
+      "additionalProperties": false,
+      "properties": {
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dependencyTypes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "isIgnored": {
           "const": true,
           "type": "boolean"
@@ -235,13 +332,147 @@
             "type": "string"
           },
           "type": "array"
+        }
+      },
+      "required": [
+        "dependencies",
+        "isIgnored",
+        "packages"
+      ],
+      "type": "object"
+    },
+    "VersionGroupConfig.Pinned": {
+      "additionalProperties": false,
+      "properties": {
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dependencyTypes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "label": {
+          "type": "string"
+        },
+        "packages": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "pinVersion": {
           "type": "string"
+        }
+      },
+      "required": [
+        "dependencies",
+        "packages",
+        "pinVersion"
+      ],
+      "type": "object"
+    },
+    "VersionGroupConfig.SameRange": {
+      "additionalProperties": false,
+      "properties": {
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dependencyTypes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "label": {
+          "type": "string"
+        },
+        "packages": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "policy": {
           "const": "sameRange",
           "type": "string"
+        }
+      },
+      "required": [
+        "dependencies",
+        "packages",
+        "policy"
+      ],
+      "type": "object"
+    },
+    "VersionGroupConfig.SnappedTo": {
+      "additionalProperties": false,
+      "properties": {
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dependencyTypes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "label": {
+          "type": "string"
+        },
+        "packages": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "snapTo": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "dependencies",
+        "packages",
+        "snapTo"
+      ],
+      "type": "object"
+    },
+    "VersionGroupConfig.Standard": {
+      "additionalProperties": false,
+      "properties": {
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dependencyTypes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "label": {
+          "type": "string"
+        },
+        "packages": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "preferVersion": {
           "enum": [
@@ -249,12 +480,6 @@
             "lowestSemver"
           ],
           "type": "string"
-        },
-        "snapTo": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
         }
       },
       "required": [

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,267 @@
+{
+  "$ref": "#/definitions/RcFile",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "CustomTypeConfig.Any": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/CustomTypeConfig.NameAndVersionProps"
+        },
+        {
+          "$ref": "#/definitions/CustomTypeConfig.NamedVersionString"
+        },
+        {
+          "$ref": "#/definitions/CustomTypeConfig.UnnamedVersionString"
+        },
+        {
+          "$ref": "#/definitions/CustomTypeConfig.VersionsByName"
+        }
+      ]
+    },
+    "CustomTypeConfig.NameAndVersionProps": {
+      "additionalProperties": false,
+      "properties": {
+        "namePath": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "strategy": {
+          "const": "name~version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "namePath",
+        "path",
+        "strategy"
+      ],
+      "type": "object"
+    },
+    "CustomTypeConfig.NamedVersionString": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "strategy": {
+          "const": "name@version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "strategy"
+      ],
+      "type": "object"
+    },
+    "CustomTypeConfig.UnnamedVersionString": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "strategy": {
+          "const": "version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "strategy"
+      ],
+      "type": "object"
+    },
+    "CustomTypeConfig.VersionsByName": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "strategy": {
+          "const": "versionsByName",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "strategy"
+      ],
+      "type": "object"
+    },
+    "RcFile": {
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "customTypes": {
+          "additionalProperties": {
+            "$ref": "#/definitions/CustomTypeConfig.Any"
+          },
+          "type": "object"
+        },
+        "dependencyTypes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "filter": {
+          "type": "string"
+        },
+        "indent": {
+          "type": "string"
+        },
+        "semverGroups": {
+          "items": {
+            "$ref": "#/definitions/SemverGroupConfig.Any"
+          },
+          "type": "array"
+        },
+        "semverRange": {
+          "$ref": "#/definitions/SemverRange"
+        },
+        "sortAz": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "sortFirst": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "source": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "versionGroups": {
+          "items": {
+            "$ref": "#/definitions/VersionGroupConfig.Any"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "SemverGroupConfig.Any": {
+      "additionalProperties": false,
+      "properties": {
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dependencyTypes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "isIgnored": {
+          "const": true,
+          "type": "boolean"
+        },
+        "label": {
+          "type": "string"
+        },
+        "packages": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "range": {
+          "$ref": "#/definitions/SemverRange"
+        }
+      },
+      "required": [
+        "dependencies",
+        "packages"
+      ],
+      "type": "object"
+    },
+    "SemverRange": {
+      "default": "",
+      "description": "Aliases for semver range formats supported by syncpack\n\nDefaults to `\"\"` to ensure that exact dependency versions are used instead of loose ranges, but this can be overridden in your config file or via the `--semver-range` command line option.\n\n| Supported Range |   Example | | --------------- | --------: | | `\"<\"`           |  `<1.4.2` | | `\"<=\"`          | `<=1.4.2` | | `\"\"`            |   `1.4.2` | | `\"~\"`           |  `~1.4.2` | | `\"^\"`           |  `^1.4.2` | | `\">=\"`          | `>=1.4.2` | | `\">\"`           |  `>1.4.2` | | `\"*\"`           |       `*` |",
+      "enum": [
+        "",
+        "*",
+        ">",
+        ">=",
+        ".x",
+        "<",
+        "<=",
+        "^",
+        "~"
+      ],
+      "type": "string"
+    },
+    "VersionGroupConfig.Any": {
+      "additionalProperties": false,
+      "properties": {
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dependencyTypes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "isBanned": {
+          "const": true,
+          "type": "boolean"
+        },
+        "isIgnored": {
+          "const": true,
+          "type": "boolean"
+        },
+        "label": {
+          "type": "string"
+        },
+        "packages": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "pinVersion": {
+          "type": "string"
+        },
+        "policy": {
+          "const": "sameRange",
+          "type": "string"
+        },
+        "preferVersion": {
+          "enum": [
+            "highestSemver",
+            "lowestSemver"
+          ],
+          "type": "string"
+        },
+        "snapTo": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "dependencies",
+        "packages"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -38,7 +38,7 @@ export namespace SemverGroupConfig {
     range: SemverRange;
   }
 
-  export type Any = GroupConfig & Partial<Ignored & WithRange>;
+  export type Any = Ignored | WithRange;
 }
 
 export namespace VersionGroupConfig {
@@ -70,7 +70,7 @@ export namespace VersionGroupConfig {
     preferVersion?: 'highestSemver' | 'lowestSemver';
   }
 
-  export type Any = GroupConfig & Partial<Banned & Ignored & Pinned & SameRange & SnappedTo & Standard>;
+  export type Any = Banned | Ignored | Pinned | SameRange | SnappedTo | Standard;
 }
 
 namespace CustomTypeConfig {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,5 +1,4 @@
 import * as Context from '@effect/data/Context';
-import type { Union } from 'ts-toolbelt';
 
 /**
  * Aliases for semver range formats supported by syncpack
@@ -39,7 +38,7 @@ export namespace SemverGroupConfig {
     range: SemverRange;
   }
 
-  export type Any = Union.Strict<Ignored | WithRange>;
+  export type Any = GroupConfig & Partial<Ignored & WithRange>;
 }
 
 export namespace VersionGroupConfig {
@@ -71,7 +70,7 @@ export namespace VersionGroupConfig {
     preferVersion?: 'highestSemver' | 'lowestSemver';
   }
 
-  export type Any = Union.Strict<Banned | Ignored | Pinned | SameRange | SnappedTo | Standard>;
+  export type Any = GroupConfig & Partial<Banned & Ignored & Pinned & SameRange & SnappedTo & Standard>;
 }
 
 namespace CustomTypeConfig {
@@ -96,9 +95,7 @@ namespace CustomTypeConfig {
     strategy: 'versionsByName';
   }
 
-  export type Any = Union.Strict<
-    NameAndVersionProps | NamedVersionString | UnnamedVersionString | VersionsByName
-  >;
+  export type Any = NameAndVersionProps | NamedVersionString | UnnamedVersionString | VersionsByName;
 }
 
 export interface CliConfig {

--- a/src/env/default-env.ts
+++ b/src/env/default-env.ts
@@ -1,8 +1,6 @@
 import { cosmiconfigSync } from 'cosmiconfig';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore Select *does* exist
+// @ts-expect-error Select *does* exist
 import { Input, Select } from 'enquirer';
-import { readFileSync, readJsonSync, writeFileSync } from 'fs-extra';
 import * as globby from 'globby';
 import { join } from 'path';
 import * as readYamlFile from 'read-yaml-file';
@@ -11,6 +9,7 @@ import type { O } from 'ts-toolbelt';
 import type { RcConfig } from '../config/types';
 import { CWD } from '../constants';
 import { logVerbose } from '../lib/log-verbose';
+import * as fs from "fs";
 
 export interface DefaultEnv {
   readonly askForChoice: (opts: { message: string; choices: string[] }) => Promise<string>;
@@ -52,7 +51,8 @@ export const defaultEnv: DefaultEnv = {
     const result = configPath ? client.load(configPath) : client.search();
     if (!isNonEmptyObject(result)) {
       const rcPath = join(CWD, 'package.json');
-      const pjson = readJsonSync(rcPath, { throws: false });
+      const raw = fs.readFileSync(rcPath, { encoding: 'utf8' });
+      const pjson = JSON.parse(raw);
       const rcConfig = pjson?.config?.syncpack;
       if (isNonEmptyObject(rcConfig)) return rcConfig;
       logVerbose('no config file found');
@@ -67,7 +67,7 @@ export const defaultEnv: DefaultEnv = {
   /* istanbul ignore next */
   readFileSync(filePath) {
     logVerbose('readFileSync(', filePath, ')');
-    return readFileSync(filePath, { encoding: 'utf8' });
+    return fs.readFileSync(filePath, { encoding: 'utf8' });
   },
   /* istanbul ignore next */
   readYamlFileSync<T = unknown>(filePath: string): T {
@@ -77,6 +77,6 @@ export const defaultEnv: DefaultEnv = {
   /* istanbul ignore next */
   writeFileSync(filePath, contents) {
     logVerbose('writeFileSync(', filePath, contents, ')');
-    writeFileSync(filePath, contents);
+    fs.writeFileSync(filePath, contents);
   },
 };

--- a/src/get-semver-groups/index.ts
+++ b/src/get-semver-groups/index.ts
@@ -17,6 +17,7 @@ import { sortByName } from '../lib/sort-by-name';
 import { FilteredOutSemverGroup } from './filtered-out';
 import { IgnoredSemverGroup } from './ignored';
 import { WithRangeSemverGroup } from './with-range';
+import type { SemverGroupConfig } from "../config/types";
 
 export type AnySemverGroup = Union.Strict<
   FilteredOutSemverGroup | IgnoredSemverGroup | WithRangeSemverGroup
@@ -115,7 +116,8 @@ function createSemverGroups(
   ];
 
   if (isNonEmptyArray(rcFile.semverGroups)) {
-    rcFile.semverGroups.forEach((config) => {
+    // @ts-expect-error TODO: fix this
+    rcFile.semverGroups.forEach((config: SemverGroupConfig.Any) => {
       if (!isObject(config)) {
         return semverGroups.push(
           Effect.fail(
@@ -152,7 +154,7 @@ function createSemverGroups(
       const dependencyTypes = isArrayOfStrings(config.dependencyTypes)
         ? config.dependencyTypes
         : [];
-
+      
       if (config.isIgnored === true) {
         semverGroups.push(
           Effect.succeed(

--- a/src/get-version-groups/index.ts
+++ b/src/get-version-groups/index.ts
@@ -19,6 +19,7 @@ import { PinnedVersionGroup } from './pinned';
 import { SameRangeVersionGroup } from './same-range';
 import { SnappedToVersionGroup } from './snapped-to';
 import { StandardVersionGroup } from './standard';
+import type{ VersionGroupConfig } from "../config/types";
 
 export type AnyVersionGroup = Union.Strict<
   | BannedVersionGroup
@@ -175,7 +176,8 @@ function createVersionGroups(
   ];
 
   if (isNonEmptyArray(rcFile.versionGroups)) {
-    rcFile.versionGroups.forEach((config) => {
+    // @ts-expect-error TODO: fix this
+    rcFile.versionGroups.forEach((config: VersionGroupConfig.Any) => {
       if (!isObject(config)) {
         return versionGroups.push(
           Effect.fail(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 import type { RcConfig } from './config/types';
 
-export type RcFile = Partial<RcConfig>;
+export type RcFile = Partial<RcConfig & {
+  $schema?: string;
+}>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -833,7 +833,7 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
-"@types/json-schema@^7.0.9":
+"@types/json-schema@^7.0.11", "@types/json-schema@^7.0.9":
   version "7.0.12"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
   integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
@@ -842,13 +842,6 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
-
-"@types/jsonfile@*":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@types/jsonfile/-/jsonfile-6.1.1.tgz#ac84e9aefa74a2425a0fb3012bdea44f58970f1b"
-  integrity sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==
-  dependencies:
-    "@types/node" "*"
 
 "@types/node@*":
   version "20.2.5"
@@ -1401,6 +1394,11 @@ commander@11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-11.0.0.tgz#43e19c25dbedc8256203538e8d7e9346877a6f67"
   integrity sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==
+
+commander@^9.4.1:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
+  integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -2038,6 +2036,17 @@ glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^8.0.3:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
@@ -2076,7 +2085,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
+graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -2823,19 +2832,10 @@ json5@^1.0.2:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.2.2, json5@^2.2.3:
+json5@^2.2.1, json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
-
-jsonfile@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
-  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
-  dependencies:
-    universalify "^2.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -2966,6 +2966,13 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimatch@^9.0.1:
   version "9.0.1"
@@ -3358,6 +3365,11 @@ safe-regex-test@^1.0.0:
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
 
+safe-stable-stringify@^2.4.1:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
+  integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
+
 semver@7.5.3, semver@^7.5.3:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
@@ -3590,6 +3602,19 @@ ts-jest@29.1.1:
     semver "^7.5.3"
     yargs-parser "^21.0.1"
 
+ts-json-schema-generator@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ts-json-schema-generator/-/ts-json-schema-generator-1.2.0.tgz#5ccce26c7475ff60a034885bff6bd38e574fb073"
+  integrity sha512-tUMeO3ZvA12d3HHh7T/AK8W5hmUhDRNtqWRHSMN3ZRbUFt+UmV0oX8k1RK4SA+a+BKNHpmW2v06MS49e8Fi3Yg==
+  dependencies:
+    "@types/json-schema" "^7.0.11"
+    commander "^9.4.1"
+    glob "^8.0.3"
+    json5 "^2.2.1"
+    normalize-path "^3.0.0"
+    safe-stable-stringify "^2.4.1"
+    typescript "~4.9.3"
+
 ts-node@10.9.1:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
@@ -3672,6 +3697,11 @@ typescript@5.1.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
+typescript@~4.9.3:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
@@ -3681,11 +3711,6 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
-
-universalify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
-  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 update-browserslist-db@^1.0.11:
   version "1.0.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,14 +799,6 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
-"@types/fs-extra@11.0.1":
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-11.0.1.tgz#f542ec47810532a8a252127e6e105f487e0a6ea5"
-  integrity sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==
-  dependencies:
-    "@types/jsonfile" "*"
-    "@types/node" "*"
-
 "@types/graceful-fs@^4.1.3":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.6.tgz#e14b2576a1c25026b7f02ede1de3b84c3a1efeae"
@@ -1940,15 +1932,6 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
-
-fs-extra@11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
-  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description

I would like to have the benefits of https://github.com/JamieMason/syncpack/issues/130 without using js.

## Justification (Why)

#146 

## How Can This Be Tested?

* Create a JSON file
* Define field `$schema` with value `https://raw.githubusercontent.com/UnderKoen/syncpack/main/schema.json`
* Make a valid / invalid config and test
* Alternatively you can use https://www.jsonschemavalidator.net/ for testing, here you need to paste the content of `schema.json`
