### PR TITLE
Update `filter` docs to use `--filter`

### DIFF
--- a/site/src/partials/option/_filter.mdx
+++ b/site/src/partials/option/_filter.mdx
@@ -7,8 +7,8 @@ Only run `syncpack {props.command}` on dependencies whose names match the given 
 {/* prettier-ignore-start */}
 <pre><code>{`
 \# only include react, react-dom, preact etc
-syncpack ${props.command} --types 'react'
+syncpack ${props.command} --filter 'react'
 \# only include typescript or eslint packages
-syncpack ${props.command} --types 'typescript|eslint'
+syncpack ${props.command} --filter 'typescript|eslint'
 `.trim()}</code></pre>
 {/* prettier-ignore-end */}


### PR DESCRIPTION
## Description (What)

👋 just updates docs to use `filter` instead of `type` here:

https://jamiemason.github.io/syncpack/command/update/

![CleanShot 2023-11-19 at 20 40 33@2x](https://github.com/JamieMason/syncpack/assets/9790196/0b46de6d-b292-47bf-9ec0-935b24f4c7f9)


## Justification (Why)

to be accurate. 🤔 


## How Can This Be Tested?

just a doc change.