### PR TITLE
Explicitly add dependency `fast-check`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cosmiconfig": "9.0.0",
         "effect": "2.0.0-next.62",
         "enquirer": "2.4.1",
+        "fast-check": "3.15.0",
         "globby": "11.1.0",
         "minimatch": "9.0.3",
         "npm-package-arg": "11.0.1",
@@ -3724,7 +3725,6 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
-      "peer": true,
       "dependencies": {
         "pure-rand": "^6.0.0"
       },
@@ -6580,8 +6580,7 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fast-check"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "cosmiconfig": "9.0.0",
     "effect": "2.0.0-next.62",
     "enquirer": "2.4.1",
+    "fast-check": "3.15.0",
     "globby": "11.1.0",
     "minimatch": "9.0.3",
     "npm-package-arg": "11.0.1",


### PR DESCRIPTION
## Description (What)

Since 12.0.0, `pnpm add syncpack` has been failing under pnpm [strict mode](https://pnpm.io/next/npmrc#strict-peer-dependencies) because `fast-check` isn't declared as a dependency:

```
 ERR_PNPM_PEER_DEP_ISSUES  Unmet peer dependencies

.
└─┬ syncpack 12.0.0
  ├─┬ @effect/schema 0.56.0
  │ └── ✕ missing peer fast-check@^3.13.2
  └─┬ @effect/match 0.40.0
    └── ✕ unmet peer effect@2.0.0-next.47: found 2.0.0-next.62
Peer dependencies that should be installed:
  fast-check@^3.13.2

hint: If you want peer dependencies to be automatically installed, add "auto-install-peers=true" to an .npmrc file at the root of your project.
hint: If you don't want pnpm to fail on peer dependency issues, add "strict-peer-dependencies=false" to an .npmrc file at the root of your project.
```

<!--
Add context so reviewers understand what it is they're looking at. Describe what
this change does and what was required to deliver it. This section also helps
those who might need to modify your code at a time when you're not available,
and need help understanding it in order to get started.
-->

## Justification (Why)

As a CLI tool, `syncpack` should be self-contained and shouldn't require the callsite to install peer deps

<!--
Describe why this change is required, what problem it solves, and what
alternatives exist that you might have considered. This helps reviewers
understand the value of this change, or to highlight unnecessary changes which
can be avoided.
-->

## How Can This Be Tested?

<!--
Bullet-list how reviewers can install, build, test, and run your changes.
-->

Run `pnpm add syncpack` with a strict `.npmrc`:

```
auto-install-peers=false
strict-peer-dependencies=true
```