### PR TITLE
docs(site): fix specifierTypes examples

### DIFF
--- a/site/src/content/docs/config/specifier-types.mdx
+++ b/site/src/content/docs/config/specifier-types.mdx
@@ -13,7 +13,7 @@ Dependencies can be toggled on and off by the type of version specifier they hav
 
 ```json title=".syncpackrc"
 {
-  "dependencyTypes": ["latest", "workspace-protocol"]
+  "specifierTypes": ["latest", "workspace-protocol"]
 }
 ```
 
@@ -25,7 +25,7 @@ Everything **except** specifiers of the format `file:path/to/package.tgz` will b
 
 ```json title=".syncpackrc"
 {
-  "dependencyTypes": ["!file"]
+  "specifierTypes": ["!file"]
 }
 ```
 


### PR DESCRIPTION
## Description (What)

Replace `dependencyTypes` with `specifierTypes` in `specifierTypes` documentation examples.

## Justification (Why)

The documentation refers to `specifierTypes`, not `dependencyTypes`.

## How Can This Be Tested?

No tests are necessary.