### PR TITLE
[site] Update customTypes docs

### DIFF
--- a/site/src/partials/examples/_engines-node.mdx
+++ b/site/src/partials/examples/_engines-node.mdx
@@ -35,10 +35,18 @@ syncpack fix-mismatches --types nodeEngine
 
 <Hx level={props.level}>3. Track them in future</Hx>
 
-Add your new custom type to your `dependencyTypes`.
+Add your new custom type to your `dependencyTypes` at the root level.
+It is included in the list of all possible dependency types.
 
 ```json title=".syncpackrc"
 {
+  "customTypes": {
+    "nodeEngine": {
+      "path": "engines.node",
+      "strategy": "version"
+    }
+  },
+
   "dependencyTypes": [
     "dev"
     "nodeEngine"
@@ -56,16 +64,29 @@ syncpack list
 
 <Hx level={props.level}>4. Relax the rules (optional)</Hx>
 
-If you don't want the Node.js version to be identical in every package but do want them all to be compatible with each other, you can use a [Same Range](/syncpack/config/version-groups/same-range) Version Group.
+If you don't want the Node.js version to be identical in every package but do 
+want them all to be compatible with each other, you can use a 
+[Same Range](/syncpack/config/version-groups/same-range) Version Group.
+
+Note that you do have to list your customType in `dependencyTypes` for it to
+work within `versionGroups#dependencyTypes` or `semverGroups#dependencyTypes`.
 
 ```json title=".syncpackrc"
 {
+  "customTypes": {
+    "nodeEngine": {
+      "path": "engines.node",
+      "strategy": "version"
+    }
+  },
+  
   "dependencyTypes": [
     "dev"
     "nodeEngine"
     "peer"
     "prod"
   ],
+
   "versionGroups": [
     {
       "dependencyTypes": ["nodeEngine"],


### PR DESCRIPTION
## Description (What)

Updating customTypes documentation so that the examples in there are less confusing.

## Justification (Why)

https://github.com/JamieMason/syncpack/issues/201

## How Can This Be Tested?

`npm run dev -w site`