### PR TITLE
fix: use localeCompare for sorting

### DIFF
--- a/src/bin-format/format.spec.ts
+++ b/src/bin-format/format.spec.ts
@@ -128,13 +128,17 @@ describe('sortAz', () => {
   it('sorts object properties alphabetically by key', async () => {
     const scenario = createScenario({
       '.syncpackrc': {
-        sortAz: ['scripts'],
+        sortAz: ['dependencies'],
       },
       'package.json': {
         name: 'a',
-        scripts: {
-          B: '',
-          A: '',
+        dependencies: {
+          'B': '',
+          '@B': '',
+          '1B': '',
+          'A': '',
+          '@A': '',
+          '1A': ''
         },
       },
     })();
@@ -142,7 +146,7 @@ describe('sortAz', () => {
     await Effect.runPromiseExit(format(scenario));
 
     const packages: any = scenario.readPackages();
-    expect(Object.keys(packages.a.scripts)).toEqual(['A', 'B']);
+    expect(Object.keys(packages.a.dependencies)).toEqual(['@A', '@B', '1A', '1B', 'A', 'B']);
     expect(scenario.io.process.exit).not.toHaveBeenCalled();
   });
 
@@ -153,7 +157,7 @@ describe('sortAz', () => {
       },
       'package.json': {
         name: 'a',
-        keywords: ['B', 'A'],
+        keywords: ['B', '@B', '1B', 'A', '@A', '1A'],
       },
     })();
 
@@ -161,7 +165,7 @@ describe('sortAz', () => {
 
     expect(scenario.readPackages()).toHaveProperty('a', {
       name: 'a',
-      keywords: ['A', 'B'],
+      keywords: ['@A', '@B', '1A', '1B', 'A', 'B'],
     });
     expect(scenario.io.process.exit).not.toHaveBeenCalled();
   });

--- a/src/bin-format/format.ts
+++ b/src/bin-format/format.ts
@@ -16,6 +16,7 @@ import type { Io } from '../io/index.js';
 import { IoTag } from '../io/index.js';
 import { writeIfChanged } from '../io/write-if-changed.js';
 import { withLogger } from '../lib/with-logger.js';
+import type { PackageJson } from '../get-package-json-files/package-json-file.js';
 
 interface Input {
   io: Io;
@@ -117,10 +118,11 @@ function sortObject(sortedKeys: string[] | Set<string>, obj: Record<string, unkn
   });
 }
 
-function sortAlphabetically(value: unknown): void {
+function sortAlphabetically(value: PackageJson[keyof PackageJson]): void {
+  const localeComparison = (a: string, b: string) => a.localeCompare(b);
   if (isArray(value)) {
-    value.sort();
+    value.sort(localeComparison);
   } else if (isObject(value)) {
-    sortObject(Object.keys(value).sort(), value);
+    sortObject(Object.keys(value).sort(localeComparison), value);
   }
 }


### PR DESCRIPTION
## Description 

Update `sortAlphabetically` to use `localeCompare`

## Justification (Why)

Addresses https://github.com/JamieMason/syncpack/issues/206

## How Can This Be Tested?

 Test were updated