### PR TITLE
fix: use types export in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "node": ">=16"
   },
   "exports": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This is to provide TS based autocomplete for config fields when type is used like this

```
/** @type {import("syncpack").RcFile} */
const config = {
  sortFirst: ['name', 'description', 'version', 'scripts'],
};
```

Without this PR RcFile type can not be resolved.