### PR TITLE
Update schema example to reference node_modules

### DIFF
--- a/site/src/partials/_json-schema.mdx
+++ b/site/src/partials/_json-schema.mdx
@@ -1,8 +1,8 @@
-From syncpack 11.2.1 and up, a JSON Schema file is available. Ironically, you will need to manually ensure that the version number in the URL you reference matches the version of syncpack you have installed, at least for the time being.
+From syncpack 11.2.1 and up, a JSON Schema file is available.
 
 ```json title=".syncpackrc"
 {
-  "$schema": "https://unpkg.com/syncpack@11.2.1/dist/schema.json",
+  "$schema": "./node_modules/syncpack/dist/schema.json",
   "versionGroups": [
     {
       "dependencies": ["@types/node"],


### PR DESCRIPTION
## Description (What)

Use the schema in the installed syncpack package in node_modules

## Justification (Why)

Avoids referencing an external schema and needing to keep the version up to date.

## How Can This Be Tested?

Open a .syncpackrc file with this change in VSCode and note the code suggestions

![Screenshot 2024-08-22 at 10 12 30 AM](https://github.com/user-attachments/assets/8bd9829e-8141-4da9-9c3e-0a13c657c69a)