### PR TITLE
fix(types): allow additional properties on customTypes

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -158,7 +158,9 @@ export interface RcConfig {
   /** @see https://jamiemason.github.io/syncpack/integrations/json-schema */
   $schema?: string;
   /** @see https://jamiemason.github.io/syncpack/config/custom-types */
-  customTypes: Record<string, CustomTypeConfig.Any>;
+  customTypes: {
+    [name: string]: CustomTypeConfig.Any;
+  };
   /** @see https://jamiemason.github.io/syncpack/config/dependency-types */
   dependencyTypes: DependencyType[];
   /** @see https://jamiemason.github.io/syncpack/config/filter */


### PR DESCRIPTION
## Description (What)
diff of generated json schema
![image](https://github.com/user-attachments/assets/7ce90907-e464-442c-a3f2-7135e59e1563)
<img width="1647" alt="image" src="https://github.com/user-attachments/assets/b569c0ef-d280-43e3-bc48-4d68bcccd870" />



<!--
Add context so reviewers understand what it is they're looking at. Describe what
this change does and what was required to deliver it. This section also helps
those who might need to modify your code at a time when you're not available,
and need help understanding it in order to get started.
-->

## Justification (Why)
can't use customTypes with json schema
<!--
Describe why this change is required, what problem it solves, and what
alternatives exist that you might have considered. This helps reviewers
understand the value of this change, or to highlight unnecessary changes which
can be avoided.
-->

## How Can This Be Tested?
Run `pnpm run build:json-schema` and compare `dist/schema.json`
<!--
Bullet-list how reviewers can install, build, test, and run your changes.
-->
