### PR TITLE
chore: add usage trend

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,11 @@ Interactively update packages to the latest versions from the npm registry, wher
 - [![NPM version](http://img.shields.io/npm/v/syncpack.svg?style=flat-square)](https://www.npmjs.com/package/syncpack)
 - [![NPM downloads](http://img.shields.io/npm/dm/syncpack.svg?style=flat-square)](https://www.npmjs.com/package/syncpack)
 - [![Build Status](https://img.shields.io/github/actions/workflow/status/JamieMason/syncpack/ci.yaml?branch=main)](https://github.com/JamieMason/syncpack/actions)
+
+## Usage Trend
+
+[Usage Trend of syncpack](https://npm-compare.com/syncpack#timeRange=THREE_YEARS)
+  
+<a href="https://npm-compare.com/syncpack#timeRange=THREE_YEARS" target="_blank">
+  <img src="https://npm-compare.com/img/npm-trend/THREE_YEARS/syncpack.png" width="100%" alt="npm Usage Trend of syncpack" />
+</a>


### PR DESCRIPTION
hi, 

I am a maintainer of npm-compare.com, and I noticed that your package, [syncpack](https://npm-compare.com/syncpack
), has been consistently useful for many developers. To help highlight the growing popularity and usage of syncpack, I would like to propose adding a dynamic npm downloads trend image to your README. This visual representation could serve as a helpful indicator for potential new users, showcasing the package's adoption and success over time.

The trend image will be automatically updated and reflects real-time download statistics, enabling prospective users to see how syncpack is performing very well. 

Additionally, if there are any other features or functionalities from npm-compare.com that you think could benefit syncpack, please do not hesitate to reach out.

Thank you for considering my proposal. I look forward to your feedback!
