### PR TITLE
Add missing closing quote in example

### DIFF
--- a/site/src/partials/group-config/_packages.mdx
+++ b/site/src/partials/group-config/_packages.mdx
@@ -18,7 +18,7 @@ packages: ["@my-repo/**"]
 packages: ["my-server", "my-client"]
 
 // ✅ match all packages except negated ones
-packages: ["!my-server", "!@my-repo/**]
+packages: ["!my-server", "!@my-repo/**"]
 
 // ❌ no mixing of specific and negated packages
 packages: ["my-client", "!@my-repo/**"]


### PR DESCRIPTION
## Description (What)

Lots of documentation pages like this [Banned groups](https://jamiemason.github.io/syncpack/config/version-groups/banned/) page has this example of how to specify packages, and it was missing a closing quote.

This fixes that.

## Justification (Why)

Since this is an example of how to do it correctly, it's nice if it can be copy/pasted and be valid. Additionally, the missing closing quote has a minor impact on the syntax highlighting.

## How Can This Be Tested?

N/A
