### PR TITLE
feat: add support for yarn@v4 link: syntax

### DIFF
--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -79,6 +79,7 @@ pub enum Specifier {
   Tag(Raw),
   Unsupported(Raw),
   Url(Raw),
+  Link(Raw),
   WorkspaceProtocol(WorkspaceProtocol),
 }
 
@@ -97,6 +98,8 @@ impl Specifier {
       return Self::File(raw::Raw { raw });
     } else if parser::is_url(value) {
       return Self::Url(raw::Raw { raw });
+    } else if parser::is_link(value) {
+      return Self::Link(raw::Raw { raw });
     }
 
     let sanitised = sanitise_value(value);
@@ -249,6 +252,7 @@ impl Specifier {
       Self::ComplexSemver(s) => Self::ComplexSemver(s.with_range(range)),
       Self::File(s) => Self::File(s.with_range(range)),
       Self::Git(s) => Self::Git(s.with_range(range)),
+      Self::Link(s) => Self::Link(s.with_range(range)),
       Self::None => Self::None,
       Self::Tag(s) => Self::Tag(s.with_range(range)),
       Self::Unsupported(s) => Self::Unsupported(s.with_range(range)),
@@ -267,6 +271,7 @@ impl Specifier {
       Self::ComplexSemver(s) => Self::ComplexSemver(s.with_semver(semver)),
       Self::File(s) => Self::File(s.with_semver(semver)),
       Self::Git(s) => Self::Git(s.with_semver(semver)),
+      Self::Link(s) => Self::Link(s.with_semver(semver)),
       Self::None => Self::None,
       Self::Tag(s) => Self::Tag(s.with_semver(semver)),
       Self::Unsupported(s) => Self::Unsupported(s.with_semver(semver)),
@@ -282,6 +287,7 @@ impl Specifier {
       Self::ComplexSemver(inner) => inner.raw.clone(),
       Self::File(inner) => inner.raw.clone(),
       Self::Git(inner) => inner.raw.clone(),
+      Self::Link(inner) => inner.raw.clone(),
       Self::None => "".to_string(),
       Self::Tag(inner) => inner.raw.clone(),
       Self::Unsupported(inner) => inner.raw.clone(),
@@ -313,6 +319,7 @@ impl Specifier {
       Self::ComplexSemver(_) => "range-complex",
       Self::File(_) => "file",
       Self::Git(_) => "git",
+      Self::Link(_) => "link",
       Self::None => "missing",
       Self::Tag(_) => "tag",
       Self::Unsupported(_) => "unsupported",
@@ -350,6 +357,10 @@ impl Specifier {
 
   pub fn is_workspace_protocol(&self) -> bool {
     matches!(self, Self::WorkspaceProtocol(_))
+  }
+
+  pub fn is_link(&self) -> bool {
+    matches!(self, Self::Link(_))
   }
 
   /// Are both specifiers on eg. "-alpha", or neither have a release channel?

--- a/src/specifier/parser.rs
+++ b/src/specifier/parser.rs
@@ -79,6 +79,10 @@ pub fn is_workspace_protocol(str: &str) -> bool {
   regexes::WORKSPACE_PROTOCOL.is_match(str)
 }
 
+pub fn is_link(str: &str) -> bool {
+  regexes::LINK.is_match(str)
+}
+
 pub fn is_alias(str: &str) -> bool {
   regexes::ALIAS.is_match(str)
 }

--- a/src/specifier/regexes.rs
+++ b/src/specifier/regexes.rs
@@ -63,6 +63,8 @@ lazy_static! {
   pub static ref ALIAS: Regex = Regex::new(r"^npm:.+").unwrap();
   /// "file:"
   pub static ref FILE: Regex = Regex::new(r"^file:").unwrap();
+  /// "link:"
+  pub static ref LINK: Regex = Regex::new(r"^link:").unwrap();
   /// "workspace:"
   pub static ref WORKSPACE_PROTOCOL: Regex = Regex::new(r"^workspace:").unwrap();
   /// "https://"

--- a/src/specifier_test.rs
+++ b/src/specifier_test.rs
@@ -373,6 +373,22 @@ fn file_paths() {
 }
 
 #[test]
+fn links() {
+  let cases: Vec<&str> = vec![
+    "link:../foo",
+    "link:path/to/foo"
+  ];
+  for value in cases {
+    match Specifier::new(value, None) {
+      Specifier::Link(actual) => {
+        assert_eq!(actual.raw, value)
+      },
+      _ => panic!("Expected Link")
+    }
+  }
+}
+
+#[test]
 fn urls() {
   let cases: Vec<&str> = vec![
     "http://insecure.com/foo.tgz",

--- a/src/visit_packages/preferred_semver.rs
+++ b/src/visit_packages/preferred_semver.rs
@@ -44,6 +44,12 @@ pub fn visit(dependency: &Dependency, ctx: &Context) {
         return;
       }
       debug!("{L4}it depends on the local instance");
+      if instance.descriptor.specifier.is_link() {
+        debug!("{L5}it is using the link specifier");
+        debug!("{L6}mark as satisfying local");
+        instance.mark_valid(ValidInstance::SatisfiesLocal, &instance.descriptor.specifier);
+        return;
+      }
       if instance.descriptor.specifier.is_workspace_protocol() {
         debug!("{L5}it is using the workspace protocol");
         if !ctx.config.rcfile.strict {

--- a/src/visit_packages/preferred_semver_test.rs
+++ b/src/visit_packages/preferred_semver_test.rs
@@ -466,6 +466,51 @@ mod local {
       },
     ]);
   }
+
+  #[test]
+  fn instance_is_linked() {
+    let ctx = TestBuilder::new()
+      .with_packages(vec![
+        json!({
+          "name": "package-a",
+          "version": "1.0.0"
+        }),
+        json!({
+          "name": "package-b",
+          "version": "2.0.0",
+          "dependencies": {
+            "package-a": "link:../package-a"
+          }
+        }),
+      ])
+      .build_and_visit();
+    expect(&ctx).to_have_instances(vec![
+      ExpectedInstance {
+        state: InstanceState::valid(IsLocalAndValid),
+        dependency_name: "package-b",
+        id: "package-b in /version of package-b",
+        actual: "2.0.0",
+        expected: Some("2.0.0"),
+        overridden: None,
+      },
+      ExpectedInstance {
+        state: InstanceState::valid(IsLocalAndValid),
+        dependency_name: "package-a",
+        id: "package-a in /version of package-a",
+        actual: "1.0.0",
+        expected: Some("1.0.0"),
+        overridden: None,
+      },
+      ExpectedInstance {
+        state: InstanceState::valid(IsLocalAndValid),
+        dependency_name: "package-a",
+        id: "package-a in /dependencies of package-b",
+        actual: "link:../package-a",
+        expected: Some("link:../package-a"),
+        overridden: None,
+      },
+    ]);
+  }
 }
 
 mod highest_or_lowest {


### PR DESCRIPTION
## Description (What)

Yarn @ v4 supports a `link:../path/to/thing` syntax for installing another workspace as a dependency but via a symlink. By definition of this syntax these specifiers are always equal regardless of where they are found in the tree, and always match the local version.

## Justification (Why)

Without this syntax support there is no way to use `link:` syntax without syncpack replacing it with specific version numbers which is then invalid as it results in copy-to-install behavior instead of the desired symlink behavior

## How Can This Be Tested?

This PR has unit tests
