### PR TITLE
fix(format): return exit code 0 when formatting files

### DIFF
--- a/src/effects/format.rs
+++ b/src/effects/format.rs
@@ -57,10 +57,8 @@ fn fix_formatting(ctx: Context) -> i32 {
       package.borrow().write_to_disk(&ctx.config);
     });
   }
-  if was_invalid {
-    1
-  } else {
+  if !was_invalid {
     ui::util::print_no_issues_found();
-    0
   }
+  0
 }


### PR DESCRIPTION
Fixes #300 

Format command should always return success exit code (0) when it completes successfully, regardless of whether files needed formatting. Only show "no issues found" message when no formatting was required.

Fixes regression introduced in 0d1f602 where format operations would return exit code 1 when files needed formatting.

## Description (What)

This change fixes the exit code behavior of the `syncpack format` command. The format command now always returns exit code 0 when it completes successfully, and only displays the "no issues found" message when no formatting changes were actually needed.

The fix modifies the `fix_formatting` function in `src/effects/format.rs` to:
- Always return exit code 0 (success) after formatting operations complete
- Only show "no issues found" when `!was_invalid` (no formatting was needed)

## Justification (Why)

The format command is designed to fix formatting issues, not to fail when formatting is needed. Returning exit code 1 when files need formatting breaks CI/CD pipelines and scripts that expect the format command to succeed after making necessary changes.

This was a regression introduced in commit 0d1f602 during a refactor that changed from `std::process::exit()` to returning exit codes. The logic for the format operation incorrectly adopted the same exit code behavior as the check operation, but format operations should always succeed when they complete.

## How Can This Be Tested?

- Create a test package.json with unsorted dependencies
- Run `syncpack format --source package.json`
- Verify the command returns exit code 0 (success) even when it makes formatting changes
- Verify "no issues found" message only appears when no changes were needed
- Test with the reproduction script provided in the original issue

