### PR TITLE
feat: support bunx for js configs

### DIFF
--- a/src/rcfile/javascript.rs
+++ b/src/rcfile/javascript.rs
@@ -69,7 +69,12 @@ pub fn from_javascript_path(file_path: &Path) -> Result<Rcfile, RcfileError> {
       "#
   );
 
-  Command::new("npx")
+  // Prefer bunx if a Bun lockfile exists in the same directory as the config
+  let dir = file_path.parent().unwrap_or_else(|| Path::new("."));
+  let use_bunx = dir.join("bun.lock").exists() || dir.join("bun.lockb").exists();
+  let runner = if use_bunx { "bunx" } else { "npx" };
+
+  Command::new(runner)
     .args(["tsx", "-e", &nodejs_script])
     .current_dir(file_path.parent().unwrap_or_else(|| Path::new(".")))
     .output()


### PR DESCRIPTION
## Description (What)

This change detects bun and when present uses `bunx` instead of `npx` for executing js-based config files. 

## Justification (Why)

Bun package installations may not be compatible with the npm task runner. This is the case when using a custom `BUN_INSTALL_CACHE_DIR` with the `isolated` linker setting.

## How Can This Be Tested?

<!--
Bullet-list how reviewers can install, build, test, and run your changes.
-->

1. Setup a new bun repository
2. Configure a custom cache.dir and "isolated" linker setting via `bunfig.toml`
3. Add syncpack and a `syncpack.config.ts`
4. Attempt to run `syncpack lint`

Result: `✗ Node.js/npx/tsx process failed with stderr: sh: tsx: command not found`
