### PR TITLE
fix(npm): detect musl libc to resolve correct binary on Alpine Linux

### DIFF
--- a/npm/index.cjs
+++ b/npm/index.cjs
@@ -6,7 +6,10 @@ const { dirname, join } = require('node:path');
 const args = process.argv.slice(2);
 const arch = process.arch;
 const [os, extension] = ['win32', 'cygwin'].includes(process.platform) ? ['windows', '.exe'] : [process.platform, ''];
-const optionalDep = `syncpack-${os}-${arch}`;
+const isMusl = os === 'linux' && (() => {
+  try { return require('node:fs').readFileSync('/usr/bin/ldd', 'utf8').includes('musl'); } catch { return false; }
+})();
+const optionalDep = `syncpack-${os}-${arch}${isMusl ? '-musl' : ''}`;
 const binaryName = `syncpack${extension}`;
 
 const pathToBinary = resolveBinaryPath();


### PR DESCRIPTION
## Description (What)

Adds musl libc detection to the binary resolution logic in npm/index.cjs. On Linux, the launcher now checks /usr/bin/ldd for the presence of "musl" and appends -musl to the optional dependency name when detected, resolving to syncpack-linux-{arch}-musl instead of the glibc variant.

## Justification (Why)

On Alpine Linux and other musl-based distros, syncpack fails at runtime with:

`Error relocating /node_modules/syncpack-linux-x64/bin/syncpack: __res_init: symbol not found`

The glibc-linked binary is resolved because index.cjs has no way to distinguish musl from glibc — it only considers process.platform and process.arch. The musl binary packages (syncpack-linux-x64-musl, syncpack-linux-arm64-musl) are already built and published but were unreachable.

## How Can This Be Tested?

- Alpine (musl): Run in an Alpine Docker container — node npm/index.cjs should resolve syncpack-linux-x64-musl
```
docker run --rm -it -v $(pwd):/app -w /app node:alpine node -e \
  "console.log(require('fs').readFileSync('/usr/bin/ldd','utf8').includes('musl'))"
# → true
```
- glibc Linux / macOS / Windows: Verify isMusl is false and existing behavior is unchanged
- Missing /usr/bin/ldd: The try/catch returns false, falling back to the glibc package