### PR TITLE
fix: enforce sameRange policy across different dependency names (#298)

### DIFF
--- a/src/version_group/same_range.rs
+++ b/src/version_group/same_range.rs
@@ -28,6 +28,16 @@ impl SameRangeGroup {
 
   pub fn visit(&self, ctx: &Context, _registry_updates: &Option<RegistryUpdates>) {
     let arena = &ctx.instances;
+    // Collect every instance index across all dep names in this group so that
+    // cross-dep comparisons work. Without this, a dep that appears only once
+    // (single package.json) trivially satisfies a one-element list — itself —
+    // and is always marked valid even when sibling deps have diverging versions.
+    // See: https://github.com/JamieMason/syncpack/issues/298
+    let all_indices: Vec<InstanceIdx> = self
+      .dependencies
+      .values()
+      .flat_map(|dep| dep.instances.iter().copied())
+      .collect();
     for dep in self.dependencies.values() {
       debug!("visit same range version group");
       debug!("{L1}visit dependency '{}'", dep.internal_name);
@@ -35,7 +45,7 @@ impl SameRangeGroup {
         let instance = &arena[idx.0];
         let actual_specifier = &instance.descriptor.specifier;
         debug!("{L2}visit instance '{}' ({actual_specifier:?})", instance.id);
-        if instance.already_satisfies_all(&dep.instances, arena) {
+        if instance.already_satisfies_all(&all_indices, arena) {
           debug!("{L3}its specifier satisfies all other instances in the group");
           if instance.must_match_preferred_semver_range() {
             debug!("{L4}it belongs to a semver group");

--- a/src/version_group/same_range_test.rs
+++ b/src/version_group/same_range_test.rs
@@ -691,6 +691,148 @@ async fn three_ranges_where_one_does_not_overlap_with_others() {
   ]);
 }
 
+/// Regression test for issue #298: when a sameRange version group matches
+/// multiple *different* dependency names (e.g. `@nx/*` and `nx`) and each
+/// appears only once (single package.json), each dep's DependencyCore contains
+/// exactly one instance. Previously `already_satisfies_all` received a
+/// one-element list that trivially passes — every instance satisfied only
+/// itself, so the group reported "no issues" even when the exact pinned
+/// versions diverged.
+///
+/// The fix: check each instance against ALL instances across ALL deps in the
+/// group, not just against its own dep-name's sibling instances.
+#[tokio::test]
+async fn cross_dep_exact_versions_that_differ_are_flagged_issue_298() {
+  // Mirrors the minimal repro from issue #298:
+  //   npm pkg set dependencies.nx=21.3.0 dependencies.@nx/js=21.3.1 dependencies.@nx/eslint=21.3.2
+  //   syncpack lint  →  was: "✓ No issues found"  (wrong)
+  //                 →  want: SameRangeMismatch on every instance  (correct)
+  let ctx = TestBuilder::new()
+    .with_packages(vec![json!({
+      "name": "repro",
+      "dependencies": {
+        "nx":         "21.3.0",
+        "@nx/js":     "21.3.1",
+        "@nx/eslint": "21.3.2"
+      }
+    })])
+    .with_version_groups(vec![
+      json!({
+        "dependencyTypes": ["local"],
+        "isIgnored": true
+      }),
+      json!({
+        "dependencies": ["nx", "@nx/*"],
+        "policy": "sameRange"
+      }),
+    ])
+    .run()
+    .await;
+  expect(&ctx).to_have_instances(vec![
+    ExpectedInstance {
+      state: InstanceState::valid(IsIgnored),
+      dependency_name: "repro",
+      id: "repro in /version of repro",
+      actual: "",
+      expected: Some(""),
+      overridden: None,
+      severity: None,
+    },
+    ExpectedInstance {
+      state: InstanceState::unfixable(SameRangeMismatch),
+      dependency_name: "@nx/eslint",
+      id: "@nx/eslint in /dependencies of repro",
+      actual: "21.3.2",
+      expected: Some("21.3.2"),
+      overridden: None,
+      severity: None,
+    },
+    ExpectedInstance {
+      state: InstanceState::unfixable(SameRangeMismatch),
+      dependency_name: "@nx/js",
+      id: "@nx/js in /dependencies of repro",
+      actual: "21.3.1",
+      expected: Some("21.3.1"),
+      overridden: None,
+      severity: None,
+    },
+    ExpectedInstance {
+      state: InstanceState::unfixable(SameRangeMismatch),
+      dependency_name: "nx",
+      id: "nx in /dependencies of repro",
+      actual: "21.3.0",
+      expected: Some("21.3.0"),
+      overridden: None,
+      severity: None,
+    },
+  ]);
+}
+
+/// When all cross-dep versions in the same sameRange group are identical
+/// pinned versions they should be valid (regression guard for the fix).
+#[tokio::test]
+async fn cross_dep_exact_versions_that_match_are_valid_issue_298() {
+  let ctx = TestBuilder::new()
+    .with_packages(vec![json!({
+      "name": "repro",
+      "dependencies": {
+        "nx":         "21.3.0",
+        "@nx/js":     "21.3.0",
+        "@nx/eslint": "21.3.0"
+      }
+    })])
+    .with_version_groups(vec![
+      json!({
+        "dependencyTypes": ["local"],
+        "isIgnored": true
+      }),
+      json!({
+        "dependencies": ["nx", "@nx/*"],
+        "policy": "sameRange"
+      }),
+    ])
+    .run()
+    .await;
+  expect(&ctx).to_have_instances(vec![
+    ExpectedInstance {
+      state: InstanceState::valid(IsIgnored),
+      dependency_name: "repro",
+      id: "repro in /version of repro",
+      actual: "",
+      expected: Some(""),
+      overridden: None,
+      severity: None,
+    },
+    ExpectedInstance {
+      state: InstanceState::valid(SatisfiesSameRangeGroup),
+      dependency_name: "@nx/eslint",
+      id: "@nx/eslint in /dependencies of repro",
+      actual: "21.3.0",
+      expected: Some("21.3.0"),
+      overridden: None,
+      severity: None,
+    },
+    ExpectedInstance {
+      state: InstanceState::valid(SatisfiesSameRangeGroup),
+      dependency_name: "@nx/js",
+      id: "@nx/js in /dependencies of repro",
+      actual: "21.3.0",
+      expected: Some("21.3.0"),
+      overridden: None,
+      severity: None,
+    },
+    ExpectedInstance {
+      state: InstanceState::valid(SatisfiesSameRangeGroup),
+      dependency_name: "nx",
+      id: "nx in /dependencies of repro",
+      actual: "21.3.0",
+      expected: Some("21.3.0"),
+      overridden: None,
+      severity: None,
+    },
+  ]);
+}
+
 /// Severity tests — opt out of auto-fix per status (issue #216).
 /// SameRange only permits `SemverRangeMismatch` (the only Fixable variant it
 /// produces). `SameRangeMismatch` itself is Unfixable and not user-tunable.


### PR DESCRIPTION
Fixes #298.

**Problem:** when a `versionGroups[]` entry with `policy: 'sameRange'` matches multiple different dependency names (e.g. `["nx", "@nx/*"]`) and each appears once, mismatched versions (`21.3.0` vs `21.3.1`) are NOT flagged — syncpack reports no issues. (Confirmed by @fregante in the thread.)

**Root cause:** in `src/version_group/same_range.rs`, the check ran `already_satisfies_all(&dep.instances, ...)`, where `dep.instances` is the instance list for a *single* dependency name. With one instance per name, an instance trivially satisfies its own range, so drift across different dep names in the group is never caught.

**Fix:** flatten all instances across all deps in the group into `all_indices`, and check each instance against that full set — every instance in the group must share an overlapping range with every other, including across different dep names.

**Verified:** `cargo test` — the new repro test (`cross_dep_exact_versions_that_differ_are_flagged_issue_298`) fails before the fix and passes after; 704 tests, 0 regressions.

---

Came across syncpack (use it myself) and noticed #298 had been open a while, so I fixed it. No strings — glad if it helps. I do this kind of work (Choreless — we fix and ship code for small teams), so if you ever want a hand, I'm around. — Charles
